### PR TITLE
Deploy to pypi on merge into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,11 @@ notifications:
   email:
     recipients:
       - sergio_89@ukr.net
+
+deploy:
+  provider: pypi
+  user: SergeyPirogov
+  password:
+    secure: encrypted-password
+  # Required if building on more than one python version because each build will try to deploy
+  skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ notifications:
 
 deploy:
   provider: pypi
-  user: SergeyPirogov
+  user: tillahoffmann
   password:
-    secure: encrypted-password
+    secure: "MoX7m8vD5z9PMzxyf/AW0/GJrjw75K0O5fWyzYDVK0e9fE4en4DVZQXsQ+bI5aVoOfEpAJ/wGgR4t/tsdAXolZxVyK4qM3JKfv75fHcsT1Le++S6daxruTkJY/DbkY6gj9aSMqGX9M5qumeAF4nA7VXxgQ28B0Fc65UASr4tsQ6ekqumCRpqeFMFi7IHdEm2le8J9LSxlNXOGl1QgNkC/ABPAoZiOGn/hdcugaX4BGaorwDk4if8bfonr42pizNfIkMJgCQdU0n+1KqQdm30zD1JHmVOZXryi+QZUiTLHfvpjhIlHUGr7skU0sohUwen0VEbmgezvsF303bMkfQS3zS/GlwVODv6xGFGr7Vp6sYPc3452eB9wWi08lk1evPiyiFzTb4GJR37u9bwoj22/rtePfhXvP4hZs3KXHLDn6zE2LJT+OXSRWb+UD8TqS9kHIGiR7cqRXeTnca9UyGDgAnO/Q6bYvrKcoqb94ElW4VtMvLfwqGAVWYpdD4YdLZp5FoqA+U/1MuYVV81+z8ocem5f3jnuoYfbkKFbTE0wbYozjDIeirc1Bh6ekuODakF4oKcuWdOgnO5ZEobFO45BIM5DUKkOqsfCielWdLx+A8H7v6Y04bIVwCS3NRYEsuXZoBtda3lQVYVSNGeMJUtd0TCPmzolUTTVX3K2YAe6pw="
   # Required if building on more than one python version because each build will try to deploy
   skip_existing: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ deploy:
     secure: encrypted-password
   # Required if building on more than one python version because each build will try to deploy
   skip_existing: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # testcontainers-python
 
-![testcontainer](http://robertwdempsey.com/wp-content/uploads/2015/10/docker-python.png)
-
-[![Build Status](https://travis-ci.org/SergeyPirogov/testcontainers-python.svg?branch=master)](https://travis-ci.org/SergeyPirogov/testcontainers-python) [![PyPI](https://img.shields.io/pypi/v/testcontainers.svg?style=flat-square)](https://pypi.python.org/pypi/testcontainers)
+[![Build Status](https://travis-ci.org/testcontainers/testcontainers-python.svg?branch=master)](https://travis-ci.org/testcontainers/testcontainers-python) [![PyPI](https://img.shields.io/pypi/v/testcontainers.svg?style=flat-square)](https://pypi.python.org/pypi/testcontainers)
 [![Documentation Status](https://readthedocs.org/projects/testcontainers-python/badge/?version=latest)](http://testcontainers-python.readthedocs.io/en/latest/?badge=latest)
 
 Python port for testcontainers-java that allows using docker containers for functional and/or integration testing.
@@ -49,9 +47,7 @@ MySQL example
         with config as mysql:
             e = sqlalchemy.create_engine(mysql.get_connection_url())
             result = e.execute("select version()")
-            
-It will spin up MySQL version 5.7. Then you can connect to database using ``get_connection_url()`` method which returns sqlalchemy compatible url in format ``dialect+driver://username:password@host:port/database``.
 
-[![asciicast](https://asciinema.org/a/e7p6w4z6nbluipv1n15dgmo9w.png)](https://asciinema.org/a/e7p6w4z6nbluipv1n15dgmo9w)
+It will spin up MySQL version 5.7. Then you can connect to database using ``get_connection_url()`` method which returns sqlalchemy compatible url in format ``dialect+driver://username:password@host:port/database``.
 
 # Detailed [documentation](http://testcontainers-python.readthedocs.io/en/latest/)

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,20 @@
 
 import setuptools
 
+with open('README.md') as fp:
+    long_description = fp.read()
+
 setuptools.setup(
     name='testcontainers',
     packages=setuptools.find_packages(exclude=['tests']),
-    version='2.3',
+    version='2.4',
     description=('Library provides lightweight, throwaway '
                  'instances of common databases, '
                  'Selenium web browsers, or anything else that can '
-                 'run in a Docker containers'),
+                 'run in a Docker container'),
     author='Sergey Pirogov',
     author_email='automationremarks@gmail.com',
-    url='https://github.com/SergeyPirogov/testcontainers-python',
+    url='https://github.com/testcontainers/testcontainers-python',
     keywords=['testing', 'logging', 'docker', 'test automation'],
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
@@ -49,5 +52,7 @@ setuptools.setup(
         'postgresql': ['sqlalchemy', 'psycopg2'],
         'selenium': ['selenium==2.53.1'],
         'google-cloud-pubsub': ['google-cloud-pubsub'],
-    }
+    },
+    long_description_content_type="text/markdown",
+    long_description=long_description,
 )


### PR DESCRIPTION
This PR 

* adds functionality to deploy to pypi when the master branch is built.
* bumps the minor version number.
* fixes some links in the README.

@SergeyPirogov, as I'm not a maintainer on pypi, I can't add my own encrypted password to deploy. Two options: (a) you can add me as a maintainer and I can deploy using my account, or (b) you can follow the instructions [here](https://docs.travis-ci.com/user/deployment/pypi/) to encrypt your password and add the password in the `.travis.yml` file.

This should also resolve #27.