### PR TITLE
Add -v to docker-compose down to remove created volumes again

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -23,7 +23,8 @@ class DockerCompose(object):
 
     def stop(self):
         with blindspin.spinner():
-            subprocess.call(["docker-compose", "down"], cwd=self.filepath)
+            subprocess.call(["docker-compose", "down", "-v"],
+                            cwd=self.filepath)
 
     def get_service_port(self, service_name, port):
         return self._get_service_info(service_name, port)[1]


### PR DESCRIPTION
I think it would be a nice addition to be really clean and remove all volumes that may have been created in the docker-compose. This does that.