### PR TITLE
#29 specify docker-compose file

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -8,8 +8,9 @@ from testcontainers.core.exceptions import NoSuchPortExposed
 
 
 class DockerCompose(object):
-    def __init__(self, filepath):
+    def __init__(self, filepath, compose_file_name="docker-compose.yml"):
         self.filepath = filepath
+        self.compose_file_name = compose_file_name
 
     def __enter__(self):
         return self.start()
@@ -19,7 +20,7 @@ class DockerCompose(object):
 
     def start(self):
         with blindspin.spinner():
-            subprocess.call(["docker-compose", "up", "-d"], cwd=self.filepath)
+            subprocess.call(["docker-compose", "-f", self.compose_file_name, "up", "-d"], cwd=self.filepath)
 
     def stop(self):
         with blindspin.spinner():

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -24,7 +24,7 @@ class DockerCompose(object):
 
     def stop(self):
         with blindspin.spinner():
-            subprocess.call(["docker-compose", "down", "-v"],
+            subprocess.call(["docker-compose", "-f", self.compose_file_name, "down", "-v"],
                             cwd=self.filepath)
 
     def get_service_port(self, service_name, port):


### PR DESCRIPTION
#29 
Allows user to specify the docker-compose file used by passing the parameter `compose_file_name`. Defaults to `docker-compose.yml` which maintains backwards compatibility.