### PR TITLE
Update Elasticsearch support

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -68,3 +68,12 @@ Connection detail for Oracle DB.
     sid: xe
     username: system
     password: oracle
+
+Elasticsearch
+-------------
+
+::
+
+    es = ElasticSearchContainer()
+    with es:
+        es.get_url()  # gives you the http URL to connect to Elasticsearch

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Currently available features:
 - MySql db container
 - PostgreSQL db container
 - Google Cloud PubSub emulator container
+- Elasticsearch container
 - Generic Docker containers
 
 Installation

--- a/testcontainers/elasticsearch.py
+++ b/testcontainers/elasticsearch.py
@@ -16,24 +16,23 @@ import urllib
 
 
 class ElasticsearchContainer(DockerContainer):
-    def __init__(self, image="elasticsearch:latest", port_to_expose=9200):
+    def __init__(self, image="elasticsearch:7.5.0", port_to_expose=9200):
         super(ElasticsearchContainer, self).__init__(image)
         self.port_to_expose = port_to_expose
         self.with_exposed_ports(self.port_to_expose)
-        cmd_dict = {
-            'transport.host': '127.0.0.1',
-            'http.host': '0.0.0.0',
-            'discovery.zen.minimum_master_nodes': '1'
-        }
-        command = ' '.join(['-E{0}={1}'.format(k, v) for k, v in cmd_dict.items()])
-        self.with_command(command)
+        self.with_env('transport.host', '127.0.0.1')
+        self.with_env('http.host', '0.0.0.0')
+        self.with_env('discovery.zen.minimum_master_nodes', '1')
 
     @wait_container_is_ready()
     def _connect(self):
-        port = self.get_exposed_port(self.port_to_expose)
-        res = urllib.request.urlopen('http://127.0.0.1:{}'.format(port))
+        res = urllib.request.urlopen(self.get_url())
         if res.status != 200:
             raise Exception()
+
+    def get_url(self):
+        port = self.get_exposed_port(self.port_to_expose)
+        return 'http://127.0.0.1:{}'.format(port)
 
     def start(self):
         super().start()

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,0 +1,11 @@
+import json
+import urllib
+
+from testcontainers.elasticsearch import ElasticsearchContainer
+
+
+def test_docker_run_elasticsearch():
+    config = ElasticsearchContainer()
+    with config as es:
+        resp = urllib.request.urlopen(es.get_url())
+        assert json.loads(resp.read().decode())['version']['number'] == '7.5.0'


### PR DESCRIPTION
* elasticsearch:latest no longer exists
* Entrypoint has changed too; pass stuff as environment variables instead
* Refactor method to calculate URL
* Add some testing
* Add some docs, reference in index.rst