### PR TITLE
Add option to wait for logs.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,15 @@
+import pytest
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+def test_raise_timeout():
+    with pytest.raises(TimeoutError):
+        with DockerContainer("alpine").with_command("sleep 2") as container:
+            wait_for_logs(container, "Hello from Docker!", timeout=1e-3)
+
+
+def test_wait_for_hello():
+    with DockerContainer("hello-world") as container:
+        wait_for_logs(container, "Hello from Docker!")

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -1,10 +1,11 @@
 from testcontainers.google import PubSubContainer
+from testcontainers.core.waiting_utils import wait_for_logs
 from queue import Queue
 
 
 def test_pubsub_container():
     with PubSubContainer() as pubsub:
-        import time; time.sleep(5)
+        wait_for_logs(pubsub, r"Server started, listening on \d+", timeout=10)
         # Create a new topic
         publisher = pubsub.get_publisher_client()
         topic_path = publisher.topic_path(pubsub.project, "my-topic")


### PR DESCRIPTION
Reduce test time by waiting for specific log message rather than suspending execution. Cf #52.