### PR TITLE
Add gitlab ci.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,4 +10,4 @@ tests/3.8:
   image: "python:3.8"
   script:
     - pip install -r requirements/3.8.txt
-    - pytest tests -v
+    - pytest tests -s -v --log-cli-level=debug

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+tests/3.8:
+  image: "python:3.8"
+  script:
+    - pip install -r requirements/3.8.txt
+    - pytest tests -v

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,10 @@
+variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
+
+services:
+- docker:19.03.0-dind
+
 tests/3.8:
   image: "python:3.8"
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 variables:
     DOCKER_DRIVER: overlay2
     DOCKER_TLS_CERTDIR: ""
+    DOCKER_HOST: "tcp://docker:2375"
 
 services:
 - docker:19.03.0-dind

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ tests : ${TESTS}
 
 ${TESTS} : tests/% : image/%
 	${RUN} -v /var/run/docker.sock:/var/run/docker.sock testcontainers-python:$* bash -c \
-		"flake8 && pytest -v ${ARGS}"
+		"flake8 && pytest -s -v ${ARGS}"


### PR DESCRIPTION
There appear to be a number of issues with running tests on gitlab, e.g. #68, #60, #43, #25. Hopefully running tests on gitlab as part of the build will help us catch those issues.

Unfortunately, because of https://gitlab.com/gitlab-org/gitlab/issues/5667, we cannot run gitlab builds on pull requests from forks.