### PR TITLE
Allow to pull images before compose start

### DIFF
--- a/docs/compose.rst
+++ b/docs/compose.rst
@@ -30,7 +30,7 @@ Code
 
 ::
 
-    compose = DockerCompose("/home/project")
+    compose = DockerCompose("/home/project", pull=True)
     with compose:
         host = compose.get_service_host("hub", 4444)
         port = compose.get_service_port("hub", 4444)

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -8,9 +8,14 @@ from testcontainers.core.exceptions import NoSuchPortExposed
 
 
 class DockerCompose(object):
-    def __init__(self, filepath, compose_file_name="docker-compose.yml"):
+    def __init__(
+            self,
+            filepath,
+            compose_file_name="docker-compose.yml",
+            pull=False):
         self.filepath = filepath
         self.compose_file_name = compose_file_name
+        self.pull = pull
 
     def __enter__(self):
         self.start()
@@ -21,6 +26,9 @@ class DockerCompose(object):
 
     def start(self):
         with blindspin.spinner():
+            if self.pull:
+                subprocess.call(["docker-compose", "-f", self.compose_file_name, "pull"],
+                                cwd=self.filepath)
             subprocess.call(["docker-compose", "-f", self.compose_file_name, "up", "-d"],
                             cwd=self.filepath)
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -13,6 +13,14 @@ def test_can_spawn_service_via_compose():
         assert port == "4444"
 
 
+def test_can_pull_images_before_spawning_service_via_compose():
+    with DockerCompose("tests", pull=True) as compose:
+        host = compose.get_service_host("hub", 4444)
+        port = compose.get_service_port("hub", 4444)
+        assert host == "0.0.0.0"
+        assert port == "4444"
+
+
 def test_can_throw_exception_if_no_port_exposed():
     with DockerCompose("tests") as compose:
         with pytest.raises(NoSuchPortExposed):


### PR DESCRIPTION
This PR adds `pull` option to `DockerCompose`. 
See #72 for details.