### PR TITLE
Docker-compose --build support

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -3,8 +3,8 @@ import subprocess
 import blindspin
 import requests
 
-from testcontainers.core.waiting_utils import wait_container_is_ready
 from testcontainers.core.exceptions import NoSuchPortExposed
+from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
 class DockerCompose(object):
@@ -12,10 +12,12 @@ class DockerCompose(object):
             self,
             filepath,
             compose_file_name="docker-compose.yml",
-            pull=False):
+            pull=False,
+            build=False):
         self.filepath = filepath
         self.compose_file_name = compose_file_name
         self.pull = pull
+        self.build = build
 
     def __enter__(self):
         self.start()
@@ -26,11 +28,15 @@ class DockerCompose(object):
 
     def start(self):
         with blindspin.spinner():
+            cmd = ["docker-compose", "-f", self.compose_file_name]
             if self.pull:
-                subprocess.call(["docker-compose", "-f", self.compose_file_name, "pull"],
-                                cwd=self.filepath)
-            subprocess.call(["docker-compose", "-f", self.compose_file_name, "up", "-d"],
-                            cwd=self.filepath)
+                subprocess.call(cmd + ["pull"], cwd=self.filepath)
+
+            cmd += ["up", "-d"]
+            if self.build:
+                cmd += ["--build"]
+
+            subprocess.call(cmd, cwd=self.filepath)
 
     def stop(self):
         with blindspin.spinner():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+from os.path import realpath, dirname
+from pathlib import Path
+
+TESTS_DIR = Path(realpath(dirname(__file__)))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
 from os.path import realpath, dirname
-from pathlib import Path
 
-TESTS_DIR = Path(realpath(dirname(__file__)))
+TESTS_DIR = realpath(dirname(__file__))

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -3,10 +3,11 @@ import pytest
 from testcontainers.compose import DockerCompose
 from testcontainers.core.exceptions import NoSuchPortExposed
 from testcontainers.core.utils import inside_container
+from tests import TESTS_DIR
 
 
 def test_can_spawn_service_via_compose():
-    with DockerCompose("tests") as compose:
+    with DockerCompose(TESTS_DIR) as compose:
         host = compose.get_service_host("hub", 4444)
         port = compose.get_service_port("hub", 4444)
         assert host == "0.0.0.0"
@@ -14,7 +15,7 @@ def test_can_spawn_service_via_compose():
 
 
 def test_can_pull_images_before_spawning_service_via_compose():
-    with DockerCompose("tests", pull=True) as compose:
+    with DockerCompose(TESTS_DIR, pull=True) as compose:
         host = compose.get_service_host("hub", 4444)
         port = compose.get_service_port("hub", 4444)
         assert host == "0.0.0.0"
@@ -22,12 +23,12 @@ def test_can_pull_images_before_spawning_service_via_compose():
 
 
 def test_can_throw_exception_if_no_port_exposed():
-    with DockerCompose("tests") as compose:
+    with DockerCompose(TESTS_DIR) as compose:
         with pytest.raises(NoSuchPortExposed):
             compose.get_service_host("hub", 5555)
 
 
 def test_compose_wait_for_container_ready():
-    with DockerCompose("tests") as compose:
+    with DockerCompose(TESTS_DIR) as compose:
         host = "host.docker.internal" if inside_container() else "localhost"
         compose.wait_for("http://%s:4444/wd/hub" % host)

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -22,6 +22,14 @@ def test_can_pull_images_before_spawning_service_via_compose():
         assert port == "4444"
 
 
+def test_can_build_images_before_spawning_service_via_compose():
+    with DockerCompose(TESTS_DIR, build=True) as compose:
+        host = compose.get_service_host("hub", 4444)
+        port = compose.get_service_port("hub", 4444)
+        assert host == "0.0.0.0"
+        assert port == "4444"
+
+
 def test_can_throw_exception_if_no_port_exposed():
     with DockerCompose(TESTS_DIR) as compose:
         with pytest.raises(NoSuchPortExposed):


### PR DESCRIPTION
This PR adds support to build the containers before starting the services.
Resolves #76 

Also, there's an enhancement to the tests to make them run from anywhere, it doesn't have to be project root. This was an issue when running the tests from an IDE, like PyCharm.