### PR TITLE
Fix typo: get_wrapped_contaner -> get_wrapped_container

### DIFF
--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -58,7 +58,7 @@ class DockerContainer(object):
         return self
 
     def stop(self, force=True, delete_volume=True):
-        self.get_wrapped_contaner().remove(force=force, v=delete_volume)
+        self.get_wrapped_container().remove(force=force, v=delete_volume)
 
     def __enter__(self):
         return self.start()
@@ -104,7 +104,7 @@ class DockerContainer(object):
         self.volumes[host] = mapping
         return self
 
-    def get_wrapped_contaner(self) -> Container:
+    def get_wrapped_container(self) -> Container:
         return self._container
 
     def get_docker_client(self) -> DockerClient:
@@ -113,4 +113,4 @@ class DockerContainer(object):
     def exec(self, command):
         if not self._container:
             raise ContainerStartException("Container should be started before")
-        return self.get_wrapped_contaner().exec_run(command)
+        return self.get_wrapped_container().exec_run(command)


### PR DESCRIPTION
There is an older PR for this change but it is outdated.