### PR TITLE
docker-compose: Support input of Multiple Compose Files

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -84,7 +84,7 @@ class DockerCompose(object):
     def stop(self):
         file_arguments = self._generate_file_arguments()
         with blindspin.spinner():
-            subprocess.call(["docker-compose"] + file_arguments ["down", "-v"],
+            subprocess.call(["docker-compose"] + file_arguments + ["down", "-v"],
                             cwd=self.filepath)
 
     def get_service_port(self, service_name, port):

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -58,7 +58,8 @@ class DockerCompose(object):
             pull=False):
 
         # Set to a list of file names for later use
-        compose_file_name = [compose_file_name] if isinstance(compose_file_name, str) else compose_file_name
+        if isinstance(compose_file_name, str):
+            compose_file_name = [compose_file_name]
 
         self.filepath = filepath
         self.compose_file_name = compose_file_name


### PR DESCRIPTION
At work, we are utilizing docker containers instrumented via docker-compose very heavily and need to be able to have fine control over what the docker-compose tool ingests when running tests. 

Even if this pull isn't accepted as-is, the ability to do this otherwise would be appreciated.