### PR TITLE
Allow to get logs from compose

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -30,6 +30,9 @@ class DockerCompose(object):
                 desired_capabilities=CHROME,
             )
             driver.get("http://automation-remarks.com")
+            stdout, stderr = compose.get_logs()
+            if stderr:
+                print("Errors\n:{}".format(stderr))
 
 
     .. code-block:: yaml
@@ -79,6 +82,16 @@ class DockerCompose(object):
         with blindspin.spinner():
             subprocess.call(["docker-compose", "-f", self.compose_file_name, "down", "-v"],
                             cwd=self.filepath)
+
+    def get_logs(self):
+        with blindspin.spinner():
+            process = subprocess.Popen(
+                ["docker-compose", "-f", self.compose_file_name, "logs"],
+                cwd=self.filepath,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            out, err = process.communicate()
+            return out, err
 
     def get_service_port(self, service_name, port):
         return self._get_service_info(service_name, port)[1]

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -32,7 +32,7 @@ class DockerCompose(object):
             driver.get("http://automation-remarks.com")
             stdout, stderr = compose.get_logs()
             if stderr:
-                print("Errors\n:{}".format(stderr))
+                print("Errors\\n:{}".format(stderr))
 
 
     .. code-block:: yaml

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -85,13 +85,12 @@ class DockerCompose(object):
 
     def get_logs(self):
         with blindspin.spinner():
-            process = subprocess.Popen(
+            result = subprocess.run(
                 ["docker-compose", "-f", self.compose_file_name, "logs"],
                 cwd=self.filepath,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
-            out, err = process.communicate()
-            return out, err
+                capture_output=True
+            )
+            return result.stdout, result.stderr
 
     def get_service_port(self, service_name, port):
         return self._get_service_info(service_name, port)[1]

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -88,7 +88,8 @@ class DockerCompose(object):
             result = subprocess.run(
                 ["docker-compose", "-f", self.compose_file_name, "logs"],
                 cwd=self.filepath,
-                capture_output=True
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
             return result.stdout, result.stderr
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -31,3 +31,11 @@ def test_compose_wait_for_container_ready():
     with DockerCompose("tests") as compose:
         docker = DockerClient()
         compose.wait_for("http://%s:4444/wd/hub" % docker.host())
+
+
+def test_can_get_logs():
+    with DockerCompose("tests") as compose:
+        docker = DockerClient()
+        compose.wait_for("http://%s:4444/wd/hub" % docker.host())
+        stdout, stderr = compose.get_logs()
+        assert stdout, 'There should be something on stdout'


### PR DESCRIPTION
This PR adds ability to get logs from containers started by `DockerCompose`. See https://github.com/testcontainers/testcontainers-python/issues/92