### PR TITLE
Fallback to gateway address if it is running inside a container

### DIFF
--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -93,6 +93,7 @@ class DockerContainer(object):
 
             if gateway_ip == host:
                 return self.get_docker_client().bridge_ip(self._container.id)
+            return gateway_ip
         return host
 
     def get_exposed_port(self, port) -> str:


### PR DESCRIPTION
Fix:
- Stuck when running inside docker container with docker socket is mounted. Reported by @karmux [here](https://github.com/testcontainers/testcontainers-python/issues/43#issuecomment-635504867) in issue #43 