### PR TITLE
Use compose_file_name in _get_service_info

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -87,7 +87,7 @@ class DockerCompose(object):
         return self._get_service_info(service_name, port)[0]
 
     def _get_service_info(self, service, port):
-        cmd_as_list = ["docker-compose", "port", service, str(port)]
+        cmd_as_list = ["docker-compose", "-f", self.compose_file_name, "port", service, str(port)]
         output = subprocess.check_output(cmd_as_list,
                                          cwd=self.filepath).decode("utf-8")
         result = str(output).rstrip().split(":")


### PR DESCRIPTION
Otherwise, the wrong `docker-compose.yml` is used.

This was omitted in 7bf56870964d077a082d6c5950d2010072a739d0