### PR TITLE
Support specifying multiple docker-compose.yml files

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -59,7 +59,8 @@ class DockerCompose(object):
             compose_file_name="docker-compose.yml",
             pull=False):
         self.filepath = filepath
-        self.compose_file_names = compose_file_name if type(compose_file_name) is list else [compose_file_name]
+        self.compose_file_names =\
+            compose_file_name if type(compose_file_name) is list else [compose_file_name]
         self.pull = pull
 
     def __enter__(self):

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -57,7 +57,7 @@ class DockerCompose(object):
             compose_file_name="docker-compose.yml",
             pull=False):
         self.filepath = filepath
-        self.compose_file_name = compose_file_name
+        self.compose_file_names = compose_file_name if type(compose_file_name) is list else [compose_file_name]
         self.pull = pull
 
     def __enter__(self):
@@ -67,18 +67,24 @@ class DockerCompose(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
 
+    def docker_compose_command(self):
+        docker_compose_cmd = ['docker-compose']
+        for file in self.compose_file_names:
+            docker_compose_cmd += ['-f', file]
+        return docker_compose_cmd
+
     def start(self):
         with blindspin.spinner():
             if self.pull:
-                subprocess.call(["docker-compose", "-f", self.compose_file_name, "pull"],
-                                cwd=self.filepath)
-            subprocess.call(["docker-compose", "-f", self.compose_file_name, "up", "-d"],
-                            cwd=self.filepath)
+                pull_cmd = self.docker_compose_command() + ['pull']
+                subprocess.call(pull_cmd, cwd=self.filepath)
+            up_cmd = self.docker_compose_command() + ['up']
+            subprocess.call(up_cmd, cwd=self.filepath)
 
     def stop(self):
         with blindspin.spinner():
-            subprocess.call(["docker-compose", "-f", self.compose_file_name, "down", "-v"],
-                            cwd=self.filepath)
+            down_cmd = self.docker_compose_command() + ['down', '-v']
+            subprocess.call(down_cmd, cwd=self.filepath)
 
     def get_service_port(self, service_name, port):
         return self._get_service_info(service_name, port)[1]
@@ -87,9 +93,8 @@ class DockerCompose(object):
         return self._get_service_info(service_name, port)[0]
 
     def _get_service_info(self, service, port):
-        cmd_as_list = ["docker-compose", "-f", self.compose_file_name, "port", service, str(port)]
-        output = subprocess.check_output(cmd_as_list,
-                                         cwd=self.filepath).decode("utf-8")
+        port_cmd = self.docker_compose_command() + ["port", service, str(port)]
+        output = subprocess.check_output(port_cmd, cwd=self.filepath).decode("utf-8")
         result = str(output).rstrip().split(":")
         if len(result) == 1:
             raise NoSuchPortExposed("Port {} was not exposed for service {}"

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -60,7 +60,7 @@ class DockerCompose(object):
             pull=False):
         self.filepath = filepath
         self.compose_file_names =\
-            compose_file_name if type(compose_file_name) is list else [compose_file_name]
+            compose_file_name if isinstance(compose_file_name, (list, tuple)) else [compose_file_name]
         self.pull = pull
 
     def __enter__(self):

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -22,7 +22,9 @@ class DockerCompose(object):
     -------
     ::
 
-        with DockerCompose("/home/project", pull=True) as compose:
+        with DockerCompose("/home/project",
+                           compose_file_name=["docker-compose-1.yml", "docker-compose-2.yml"],
+                           pull=True) as compose:
             host = compose.get_service_host("hub", 4444)
             port = compose.get_service_port("hub", 4444)
             driver = webdriver.Remote(

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -62,8 +62,9 @@ class DockerCompose(object):
             compose_file_name="docker-compose.yml",
             pull=False):
         self.filepath = filepath
-        self.compose_file_names =\
-            compose_file_name if isinstance(compose_file_name, (list, tuple)) else [compose_file_name]
+        self.compose_file_names = compose_file_name if isinstance(
+            compose_file_name, (list, tuple)
+        ) else [compose_file_name]
         self.pull = pull
 
     def __enter__(self):

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -80,7 +80,7 @@ class DockerCompose(object):
             if self.pull:
                 pull_cmd = self.docker_compose_command() + ['pull']
                 subprocess.call(pull_cmd, cwd=self.filepath)
-            up_cmd = self.docker_compose_command() + ['up']
+            up_cmd = self.docker_compose_command() + ['up', '-d']
             subprocess.call(up_cmd, cwd=self.filepath)
 
     def stop(self):

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -94,9 +94,10 @@ class DockerCompose(object):
             subprocess.call(down_cmd, cwd=self.filepath)
 
     def get_logs(self):
+        logs_cmd = self.docker_compose_command() + ["logs"]
         with blindspin.spinner():
             result = subprocess.run(
-                ["docker-compose", "-f", self.compose_file_name, "logs"],
+                logs_cmd,
                 cwd=self.filepath,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -93,6 +93,7 @@ class DockerContainer(object):
 
             if gateway_ip == host:
                 return self.get_docker_client().bridge_ip(self._container.id)
+            return gateway_ip
         return host
 
     def get_exposed_port(self, port) -> str:

--- a/tests/docker-compose-2.yml
+++ b/tests/docker-compose-2.yml
@@ -1,0 +1,6 @@
+mysql:
+  image: mysql
+  ports:
+    - "3306:3306"
+  environment:
+    MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -44,4 +44,4 @@ def test_can_parse_multiple_compose_files():
         host = compose.get_service_host("hub", 4444)
         port = compose.get_service_port("hub", 4444)
         assert host == "0.0.0.0"
-        assert port == "3306"
+        assert port == "4444"

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -31,3 +31,17 @@ def test_compose_wait_for_container_ready():
     with DockerCompose("tests") as compose:
         docker = DockerClient()
         compose.wait_for("http://%s:4444/wd/hub" % docker.host())
+
+
+def test_can_parse_multiple_compose_files():
+    with DockerCompose(filepath="tests",
+                       compose_file_name=["docker-compose.yml", "docker-compose-2.yml"]) as compose:
+        host = compose.get_service_host("mysql", 3306)
+        port = compose.get_service_host("mysql", 3306)
+        assert host == "0.0.0.0"
+        assert port == "3306"
+
+        host = compose.get_service_host("hub", 4444)
+        port = compose.get_service_port("hub", 4444)
+        assert host == "0.0.0.0"
+        assert port == "3306"

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -53,4 +53,3 @@ def test_can_get_logs():
         compose.wait_for("http://%s:4444/wd/hub" % docker.host())
         stdout, stderr = compose.get_logs()
         assert stdout, 'There should be something on stdout'
-

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -37,7 +37,7 @@ def test_can_parse_multiple_compose_files():
     with DockerCompose(filepath="tests",
                        compose_file_name=["docker-compose.yml", "docker-compose-2.yml"]) as compose:
         host = compose.get_service_host("mysql", 3306)
-        port = compose.get_service_host("mysql", 3306)
+        port = compose.get_service_port("mysql", 3306)
         assert host == "0.0.0.0"
         assert port == "3306"
 


### PR DESCRIPTION
With this patch, users are able to separate some common used services into a reusable `docker-compose.yml` and specify multiple `docker-compose.yml`s in the `DockerCompose` class, like 

```python
        DockerCompose(filepath=os.path.join(docker_dir, 'http'), compose_file_name=[
            'skywalking-python-sdk/tests/plugin/docker/base-compose.yml',
            'skywalking-python-sdk/tests/plugin/http/docker-compose.yml',
        ])
        cls.compose.start()
```