### PR TITLE
Fix for getaddrinfo failures on Windows 10 in MongoDbContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ docs/_build/
 .venv/
 .testrepository/
 /venv/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs/_build/
 .idea/
 .venv/
 .testrepository/
+/venv/

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,9 @@ We recommend you use a `virtual environment <https://virtualenv.pypa.io/en/stabl
 
 Note, the anonymous tier of Docker Hub rate limits downloads to 100 container image requests per six hours, and running all of the tests in the tests directory for the first time appears to exceed the limit.
 
-Also, the SQL Server tests will fail unless you have Microsoft ODBC Driver 17 for SQL Server installed, available from https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server.
+The SQL Server tests will fail unless you have Microsoft ODBC Driver 17 for SQL Server installed, available from https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server.
+
+There is an apparent bug in Docker Desktop for Windows, described at https://github.com/docker/docker-py/issues/2792, that causes the DockerContainer.getExposedPort() method to fail if it is called immediately after starting the container. Some of the test cases implement a 5 second time timeout to avoid hitting this bug.
 
 Adding requirements
 ^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ testcontainers-python
 
 Python port for testcontainers-java that allows using docker containers for functional and integration testing. Testcontainers-python provides capabilities to spin up docker containers (such as a database, Selenium web browser, or any other container) for testing.
 
+This fork of testcontainers-python fixes bugs in upstream's Windows support, and it also works on Linux and MacOS.
+
 Currently available features:
 
 * Selenium Grid containers

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,10 @@ We recommend you use a `virtual environment <https://virtualenv.pypa.io/en/stabl
     pip install -r requirements/$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])').txt
     pytest -s
 
+Note, the anonymous tier of Docker Hub rate limits downloads to 100 container image requests per six hours, and running all of the tests in the tests directory for the first time appears to exceed the limit.
+
+Also, the SQL Server tests will fail unless you have Microsoft ODBC Driver 17 for SQL Server installed, available from https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server.
+
 Adding requirements
 ^^^^^^^^^^^^^^^^^^^
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
--e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j]
+-e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j,kafka]
 codecov>=2.1.0
 flake8
 pytest

--- a/requirements/3.6.txt
+++ b/requirements/3.6.txt
@@ -91,6 +91,7 @@ jinja2==2.11.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
+kafka-python==2.0.2       # via testcontainers
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -91,6 +91,7 @@ jinja2==2.11.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
+kafka-python==2.0.2       # via testcontainers
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -85,6 +85,7 @@ jinja2==2.11.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
+kafka-python==2.0.2       # via testcontainers
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setuptools.setup(
         'mongo': ['pymongo'],
         'redis': ['redis'],
         'mssqlserver': ['pyodbc'],
-        'neo4j': ['neo4j']
+        'neo4j': ['neo4j'],
+        'kafka': ['kafka-python']
     },
     long_description_content_type="text/x-rst",
     long_description=long_description,

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -5,9 +5,8 @@ Docker compose support
 Allows to spin up services configured via :code:`docker-compose.yml`.
 """
 
-import subprocess
-
 import requests
+import subprocess
 
 from testcontainers.core.waiting_utils import wait_container_is_ready
 from testcontainers.core.exceptions import NoSuchPortExposed
@@ -55,16 +54,19 @@ class DockerCompose(object):
         expose:
             - "5555"
     """
+
     def __init__(
             self,
             filepath,
             compose_file_name="docker-compose.yml",
-            pull=False):
+            pull=False,
+            env_file=None):
         self.filepath = filepath
         self.compose_file_names = compose_file_name if isinstance(
             compose_file_name, (list, tuple)
         ) else [compose_file_name]
         self.pull = pull
+        self.env_file = env_file
 
     def __enter__(self):
         self.start()
@@ -77,12 +79,15 @@ class DockerCompose(object):
         docker_compose_cmd = ['docker-compose']
         for file in self.compose_file_names:
             docker_compose_cmd += ['-f', file]
+        if self.env_file:
+            docker_compose_cmd += ['--env-file', self.env_file]
         return docker_compose_cmd
 
     def start(self):
         if self.pull:
             pull_cmd = self.docker_compose_command() + ['pull']
             subprocess.call(pull_cmd, cwd=self.filepath)
+
         up_cmd = self.docker_compose_command() + ['up', '-d']
         subprocess.call(up_cmd, cwd=self.filepath)
 

--- a/testcontainers/core/docker_client.py
+++ b/testcontainers/core/docker_client.py
@@ -62,7 +62,7 @@ class DockerClient(object):
 
         except ValueError:
             return None
-        if 'unix' in url.scheme or 'http+docker' == url.scheme:
+        if 'unix' in url.scheme or 'npipe' in url.scheme or 'http+docker' == url.scheme:
             if inside_container():
                 ip_address = default_gateway_ip()
                 if ip_address:

--- a/testcontainers/core/docker_client.py
+++ b/testcontainers/core/docker_client.py
@@ -62,11 +62,12 @@ class DockerClient(object):
 
         except ValueError:
             return None
-        if 'http' in url.scheme or 'tcp' in url.scheme:
-            return url.hostname
-        if 'unix' in url.scheme or 'npipe' in url.scheme:
+        if 'unix' in url.scheme or 'http+docker' == url.scheme:
             if inside_container():
                 ip_address = default_gateway_ip()
                 if ip_address:
                     return ip_address
+            return "localhost"
+        if 'http' in url.scheme or 'tcp' in url.scheme:
+            return url.hostname
         return "localhost"

--- a/testcontainers/core/generic.py
+++ b/testcontainers/core/generic.py
@@ -29,7 +29,8 @@ class DbContainer(DockerContainer):
     def get_connection_url(self):
         raise NotImplementedError
 
-    def _create_connection_url(self, dialect, username, password, host=None, port=None, db_name=None):
+    def _create_connection_url(self, dialect, username, password,
+                               host=None, port=None, db_name=None):
         if self._container is None:
             raise RuntimeError("container has not been started")
         if not host:

--- a/testcontainers/core/generic.py
+++ b/testcontainers/core/generic.py
@@ -29,10 +29,11 @@ class DbContainer(DockerContainer):
     def get_connection_url(self):
         raise NotImplementedError
 
-    def _create_connection_url(self, dialect, username, password, port, db_name=None):
+    def _create_connection_url(self, dialect, username, password, host=None, port=None, db_name=None):
         if self._container is None:
             raise RuntimeError("container has not been started")
-        host = self.get_container_host_ip()
+        if not host:
+            host = self.get_container_host_ip()
         port = self.get_exposed_port(port)
         url = "{dialect}://{username}:{password}@{host}:{port}".format(
             dialect=dialect, username=username, password=password, host=host, port=port

--- a/testcontainers/kafka.py
+++ b/testcontainers/kafka.py
@@ -1,0 +1,84 @@
+import tarfile
+import time
+from io import BytesIO
+from textwrap import dedent
+
+from kafka import KafkaConsumer
+from kafka.errors import KafkaError
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+
+class KafkaContainer(DockerContainer):
+    KAFKA_PORT = 9093
+    TC_START_SCRIPT = '/tc-start.sh'
+
+    def __init__(self, image="confluentinc/cp-kafka:5.4.3", port_to_expose=KAFKA_PORT):
+        super(KafkaContainer, self).__init__(image)
+        self.port_to_expose = port_to_expose
+        self.with_exposed_ports(self.port_to_expose)
+        listeners = 'PLAINTEXT://0.0.0.0:{},BROKER://0.0.0.0:9092'.format(port_to_expose)
+        self.with_env('KAFKA_LISTENERS', listeners)
+        self.with_env('KAFKA_LISTENER_SECURITY_PROTOCOL_MAP',
+                      'BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT')
+        self.with_env('KAFKA_INTER_BROKER_LISTENER_NAME', 'BROKER')
+
+        self.with_env('KAFKA_BROKER_ID', '1')
+        self.with_env('KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR', '1')
+        self.with_env('KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS', '1')
+        self.with_env('KAFKA_LOG_FLUSH_INTERVAL_MESSAGES', '10000000')
+        self.with_env('KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS', '0')
+
+    def get_bootstrap_server(self):
+        host = self.get_container_host_ip()
+        port = self.get_exposed_port(self.port_to_expose)
+        return '{}:{}'.format(host, port)
+
+    @wait_container_is_ready()
+    def _connect(self):
+        bootstrap_server = self.get_bootstrap_server()
+        consumer = KafkaConsumer(group_id='test', bootstrap_servers=[bootstrap_server])
+        if not consumer.topics():
+            raise KafkaError("Unable to connect with kafka container!")
+
+    def tc_start(self):
+        port = self.get_exposed_port(self.port_to_expose)
+        listeners = 'PLAINTEXT://localhost:{},BROKER://$(hostname -i):9092'.format(port)
+        data = (
+            dedent(
+                """
+                #!/bin/bash
+                echo 'clientPort=2181' > zookeeper.properties
+                echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties
+                echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties
+                zookeeper-server-start zookeeper.properties &
+                export KAFKA_ZOOKEEPER_CONNECT='localhost:2181'
+                export KAFKA_ADVERTISED_LISTENERS={}
+                . /etc/confluent/docker/bash-config
+                /etc/confluent/docker/configure
+                /etc/confluent/docker/launch
+                """.format(listeners)
+            )
+            .strip()
+            .encode('utf-8')
+        )
+        self.create_file(data, KafkaContainer.TC_START_SCRIPT)
+
+    def start(self):
+        script = KafkaContainer.TC_START_SCRIPT
+        command = 'sh -c "while [ ! -f {} ]; do sleep 0.1; done; sh {}"'.format(script, script)
+        self.with_command(command)
+        super().start()
+        self.tc_start()
+        self._connect()
+        return self
+
+    def create_file(self, content: bytes, path: str):
+        with BytesIO() as archive, tarfile.TarFile(fileobj=archive, mode="w") as tar:
+            tarinfo = tarfile.TarInfo(name=path)
+            tarinfo.size = len(content)
+            tarinfo.mtime = time.time()
+            tar.addfile(tarinfo, BytesIO(content))
+            archive.seek(0)
+            self.get_wrapped_container().put_archive("/", archive)

--- a/testcontainers/postgres.py
+++ b/testcontainers/postgres.py
@@ -46,9 +46,10 @@ class PostgresContainer(DbContainer):
         self.with_env("POSTGRES_PASSWORD", self.POSTGRES_PASSWORD)
         self.with_env("POSTGRES_DB", self.POSTGRES_DB)
 
-    def get_connection_url(self):
+    def get_connection_url(self, host="localhost"):
         return super()._create_connection_url(dialect="postgresql+psycopg2",
                                               username=self.POSTGRES_USER,
                                               password=self.POSTGRES_PASSWORD,
                                               db_name=self.POSTGRES_DB,
+                                              host=host,
                                               port=self.port_to_expose)

--- a/tests/.env.test
+++ b/tests/.env.test
@@ -1,0 +1,2 @@
+TAG_MYSQL_ALLOW_EMPTY_PASSWORD="true"
+TAG_TEST_ASSERT_KEY="test_is_passed"

--- a/tests/docker-compose-3.yml
+++ b/tests/docker-compose-3.yml
@@ -1,0 +1,7 @@
+mysql:
+  image: mysql
+  ports:
+    - "3306:3306"
+  environment:
+    MYSQL_ALLOW_EMPTY_PASSWORD: ${TAG_MYSQL_ALLOW_EMPTY_PASSWORD}
+    TEST_ASSERT_KEY: ${TAG_TEST_ASSERT_KEY}

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -130,7 +130,7 @@ def test_docker_run_neo4j_latest():
 
 def test_docker_generic_db():
     mongo_container = DockerContainer("mongo:latest")
-    mongo_container.with_bind_ports(27017, 27017)
+    mongo_container.with_exposed_ports(27017)
 
     with mongo_container:
         def connect():

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 
 from testcontainers.compose import DockerCompose
 from testcontainers.core.docker_client import DockerClient
@@ -6,7 +7,7 @@ from testcontainers.core.exceptions import NoSuchPortExposed
 
 
 def test_can_spawn_service_via_compose():
-    with DockerCompose("tests") as compose:
+    with DockerCompose('tests') as compose:
         host = compose.get_service_host("hub", 4444)
         port = compose.get_service_port("hub", 4444)
         assert host == "0.0.0.0"
@@ -53,3 +54,11 @@ def test_can_get_logs():
         compose.wait_for("http://%s:4444/wd/hub" % docker.host())
         stdout, stderr = compose.get_logs()
         assert stdout, 'There should be something on stdout'
+
+
+def test_can_pass_env_params_by_env_file():
+    with DockerCompose('tests', compose_file_name='docker-compose-3.yml',
+                       env_file='.env.test') as _:
+        check_env_is_set_cmd = 'docker exec tests_mysql_1 printenv | grep TEST_ASSERT_KEY'.split()
+        out = subprocess.run(check_env_is_set_cmd, stdout=subprocess.PIPE)
+        assert out.stdout.decode('utf-8').splitlines()[0], 'test_is_passed'

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -1,0 +1,31 @@
+from kafka import KafkaConsumer, KafkaProducer, TopicPartition
+
+from testcontainers.kafka import KafkaContainer
+
+
+def test_kafka_producer_consumer():
+    with KafkaContainer() as container:
+        produce_and_consume_kafka_message(container)
+
+
+def test_kafka_producer_consumer_custom_port():
+    with KafkaContainer(port_to_expose=9888) as container:
+        assert container.port_to_expose == 9888
+        produce_and_consume_kafka_message(container)
+
+
+def produce_and_consume_kafka_message(container):
+    topic = 'test-topic'
+    bootstrap_server = container.get_bootstrap_server()
+
+    producer = KafkaProducer(bootstrap_servers=[bootstrap_server])
+    producer.send(topic, b"verification message")
+    producer.flush()
+    producer.close()
+
+    consumer = KafkaConsumer(bootstrap_servers=[bootstrap_server])
+    tp = TopicPartition(topic, 0)
+    consumer.assign([tp])
+    consumer.seek_to_beginning()
+    assert consumer.end_offsets([tp])[tp] == 1, \
+        "Expected exactly one test message to be present on test topic !"

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -2,14 +2,18 @@ from kafka import KafkaConsumer, KafkaProducer, TopicPartition
 
 from testcontainers.kafka import KafkaContainer
 
+import time
+
 
 def test_kafka_producer_consumer():
     with KafkaContainer() as container:
+        time.sleep(5)
         produce_and_consume_kafka_message(container)
 
 
 def test_kafka_producer_consumer_custom_port():
     with KafkaContainer(port_to_expose=9888) as container:
+        time.sleep(5)
         assert container.port_to_expose == 9888
         produce_and_consume_kafka_message(container)
 

--- a/tests/test_new_docker_api.py
+++ b/tests/test_new_docker_api.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+import time
 
 from testcontainers import mysql
 
@@ -19,6 +20,7 @@ def test_docker_custom_image():
     container.with_env("MYSQL_ROOT_PASSWORD", "root")
 
     with container:
+        time.sleep(5)
         port = container.get_exposed_port(3306)
         assert int(port) > 0
 

--- a/tests/test_nginx_container.py
+++ b/tests/test_nginx_container.py
@@ -7,10 +7,10 @@ from testcontainers.nginx import NginxContainer
 def test_docker_run_nginx():
     nginx_container = NginxContainer("nginx:1.13.8")
     with nginx_container as nginx:
+        time.sleep(5)
         port = nginx.port_to_expose
         url = "http://{}:{}/".format(nginx.get_container_host_ip(),
                                      nginx.get_exposed_port(port))
-        time.sleep(5)
         r = requests.get(url)
         assert(r.status_code == 200)
         assert('Welcome to nginx!' in r.text)

--- a/tests/test_nginx_container.py
+++ b/tests/test_nginx_container.py
@@ -1,4 +1,5 @@
 import requests
+import time
 
 from testcontainers.nginx import NginxContainer
 
@@ -9,6 +10,7 @@ def test_docker_run_nginx():
         port = nginx.port_to_expose
         url = "http://{}:{}/".format(nginx.get_container_host_ip(),
                                      nginx.get_exposed_port(port))
+        time.sleep(5)
         r = requests.get(url)
         assert(r.status_code == 200)
         assert('Welcome to nginx!' in r.text)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -6,6 +6,7 @@ from testcontainers.redis import RedisContainer
 def test_docker_run_redis():
     config = RedisContainer()
     with config as redis:
+        time.sleep(5)
         client = redis.get_client()
         p = client.pubsub()
         p.subscribe('test')


### PR DESCRIPTION
Windows npipe URIs are rewritten by the docker-py client library to http+docker://localnpipe. Other pipe-like URIs are rewritten this way too. So, `core/docker_client.py` should detect the http+docker scheme instead of "npipe" and return localhost. Because the check for "http" schemes will inadvertently pick up the http+docker scheme too, do the check for pipes first and for real URLs second. Fixes issue #99. All tests pass with this fix on Windows 10 with Docker Desktop running locally.