### PR TITLE
Fixed MongoDbContainer to actually use username and password

### DIFF
--- a/testcontainers/mongodb.py
+++ b/testcontainers/mongodb.py
@@ -55,17 +55,21 @@ class MongoDbContainer(DockerContainer):
         self.port_to_expose = 27017
         self.with_exposed_ports(self.port_to_expose)
 
-    def _configure(self):
+    def start(self):
+        self._configure()
+        super().start()
+        return self
 
+    def _configure(self):
         self.with_env("MONGO_INITDB_ROOT_USERNAME", self.MONGO_INITDB_ROOT_USERNAME)
         self.with_env("MONGO_INITDB_ROOT_PASSWORD", self.MONGO_INITDB_ROOT_PASSWORD)
         self.with_env("MONGO_DB", self.MONGO_DB)
 
     def get_connection_url(self):
         port = self.get_exposed_port(self.port_to_expose)
-        return "mongodb://{}:{}".format(self.get_container_host_ip(), port)
+        return "mongodb://{}:{}@{}:{}".format(self.MONGO_INITDB_ROOT_USERNAME, self.MONGO_INITDB_ROOT_PASSWORD,
+                                              self.get_container_host_ip(), port)
 
     def get_connection_client(self):
         from pymongo import MongoClient
-        return MongoClient("mongodb://{}:{}".format(self.get_container_host_ip(),
-                                                    self.get_exposed_port(self.port_to_expose)))
+        return MongoClient(self.get_connection_url())

--- a/testcontainers/mongodb.py
+++ b/testcontainers/mongodb.py
@@ -67,7 +67,8 @@ class MongoDbContainer(DockerContainer):
 
     def get_connection_url(self):
         port = self.get_exposed_port(self.port_to_expose)
-        return "mongodb://{}:{}@{}:{}".format(self.MONGO_INITDB_ROOT_USERNAME, self.MONGO_INITDB_ROOT_PASSWORD,
+        return "mongodb://{}:{}@{}:{}".format(self.MONGO_INITDB_ROOT_USERNAME,
+                                              self.MONGO_INITDB_ROOT_PASSWORD,
                                               self.get_container_host_ip(), port)
 
     def get_connection_client(self):

--- a/testcontainers/mongodb.py
+++ b/testcontainers/mongodb.py
@@ -49,7 +49,7 @@ class MongoDbContainer(DockerContainer):
     MONGO_INITDB_ROOT_PASSWORD = os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")
     MONGO_DB = os.environ.get("MONGO_DB", "test")
 
-    def __init__(self, image="mongodb:latest"):
+    def __init__(self, image="mongo:latest"):
         super(MongoDbContainer, self).__init__(image=image)
         self.command = "mongo"
         self.port_to_expose = 27017

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -1,14 +1,15 @@
 import pytest
 import sqlalchemy
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 from testcontainers.core.generic import GenericContainer
 from testcontainers.core.waiting_utils import wait_for
+from testcontainers.mongodb import MongoDbContainer
 from testcontainers.mssql import SqlServerContainer
 from testcontainers.mysql import MySqlContainer, MariaDbContainer
 from testcontainers.oracle import OracleDbContainer
 from testcontainers.postgres import PostgresContainer
-from testcontainers.mongodb import MongoDbContainer
 
 
 def test_docker_run_mysql():
@@ -71,6 +72,15 @@ def test_docker_run_mongodb():
         db.restaurants.insert_one(doc)
         cursor = db.restaurants.find({"borough": "Manhattan"})
         assert cursor.next()['restaurant_id'] == doc['restaurant_id']
+
+
+def test_docker_run_mongodb_connect_without_credentials():
+    mongo_container = MongoDbContainer()
+    with mongo_container as mongo:
+        db = MongoClient("mongodb://{}:{}".format(mongo.get_container_host_ip(),
+                                                  mongo.get_exposed_port(mongo.port_to_expose))).test
+        with pytest.raises(OperationFailure):
+            db.restaurants.insert_one({})
 
 
 def test_docker_generic_db():

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -77,8 +77,9 @@ def test_docker_run_mongodb():
 def test_docker_run_mongodb_connect_without_credentials():
     mongo_container = MongoDbContainer()
     with mongo_container as mongo:
-        db = MongoClient("mongodb://{}:{}".format(mongo.get_container_host_ip(),
-                                                  mongo.get_exposed_port(mongo.port_to_expose))).test
+        connection_url = "mongodb://{}:{}".format(mongo.get_container_host_ip(),
+                                                  mongo.get_exposed_port(mongo.port_to_expose))
+        db = MongoClient(connection_url).test
         with pytest.raises(OperationFailure):
             db.restaurants.insert_one({})
 


### PR DESCRIPTION
First thanks for the library :)

I figured that the MongoDB container doesn't actually configure the username and password, so I added that it works