### PR TITLE
Add Localstack container support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Currently available features:
 * PostgreSQL Db container
 * Microsoft SQL Server container
 * Generic docker containers
+* LocalStack
 
 Installation
 ------------

--- a/testcontainers/localstack.py
+++ b/testcontainers/localstack.py
@@ -47,7 +47,7 @@ class LocalStackContainer(DockerContainer):
     def get_endpoint_override(self):
         host = self.get_container_host_ip()
         port = self.get_exposed_port(LocalStackContainer.EDGE_PORT)
-        return f'http://{host}:{port}'
+        return 'http://{}:{}'.format(host, port)
 
     def start(self):
         super().start()

--- a/testcontainers/localstack.py
+++ b/testcontainers/localstack.py
@@ -1,0 +1,58 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.core.container import DockerContainer
+
+
+class LocalStackContainer(DockerContainer):
+    """
+    Localstack container.
+
+    Example
+    -------
+    ::
+        localstack = LocalStackContainer(image="localstack/localstack:0.11.3")
+        localstack.with_services("dynamodb", "lambda")
+        localstack.start()
+        dynamo_endpoint = localstack.get_service_endpoint()
+        dynamo_client = boto3.client("dynamodb", endpoint_url=dynamo_endpoint)
+        scan_result = dynamo_client.scan(TableName='foo')
+        # Do something with the scan result
+    """
+    EDGE_PORT = 4566
+    IMAGE = 'localstack/localstack:0.11.3'
+
+    def __init__(self, image=IMAGE):
+        super(LocalStackContainer, self).__init__(image)
+        self.with_exposed_ports(LocalStackContainer.EDGE_PORT)
+        self.with_volume_mapping('/var/run/docker.sock', '/var/run/docker.sock')
+
+    def with_services(self, *services):
+        """
+        Restrict what services to run.
+        If you don't call this, everything will be launched by default.
+        """
+        self.with_env('SERVICES', ','.join(services))
+
+    def get_endpoint_override(self):
+        host = self.get_container_host_ip()
+        port = self.get_exposed_port(LocalStackContainer.EDGE_PORT)
+        return f'http://{host}:{port}'
+
+    def start(self):
+        super().start()
+        self._get_ready_log()
+        return self
+
+    def _get_ready_log(self, timeout=30):
+        wait_for_logs(self, 'Ready\\.', timeout=timeout)

--- a/testcontainers/localstack.py
+++ b/testcontainers/localstack.py
@@ -43,10 +43,10 @@ class LocalStackContainer(DockerContainer):
         """
         return self.with_env('SERVICES', ','.join(services))
 
-    def get_endpoint_url(self):
+    def get_url(self):
         """
         Use this to call localstack instead of real AWS services.
-        ex: boto3.client('lambda', endpoint_url=localstack.get_endpoint_url())
+        ex: boto3.client('lambda', endpoint_url=localstack.get_url())
         :return: the endpoint where localstack is reachable.
         """
         host = self.get_container_host_ip()

--- a/testcontainers/localstack.py
+++ b/testcontainers/localstack.py
@@ -54,4 +54,4 @@ class LocalStackContainer(DockerContainer):
         return self
 
     def _get_ready_log(self, timeout):
-        wait_for_logs(self, 'Ready\\.', timeout=timeout)
+        wait_for_logs(self, r'Ready\.\n', timeout=timeout)

--- a/tests/test_localstack.py
+++ b/tests/test_localstack.py
@@ -1,0 +1,16 @@
+import json
+import urllib
+
+from testcontainers.localstack import LocalStackContainer
+
+
+def test_docker_run_localstack():
+    config = LocalStackContainer()
+    with config as localstack:
+        resp = urllib.request.urlopen(f"{localstack.get_endpoint_override()}/health")
+        services = json.loads(resp.read().decode())['services']
+
+        # Check that all services are running
+        assert all(value == 'running' for value in services.values())
+        # Check that some of the services keys
+        assert all(test_service in services.keys() for test_service in ['dynamodb', 'sns', 'sqs'])

--- a/tests/test_localstack.py
+++ b/tests/test_localstack.py
@@ -7,7 +7,7 @@ from testcontainers.localstack import LocalStackContainer
 def test_docker_run_localstack():
     config = LocalStackContainer()
     with config as localstack:
-        resp = urllib.request.urlopen('{}/health'.format(localstack.get_endpoint_url()))
+        resp = urllib.request.urlopen('{}/health'.format(localstack.get_url()))
         services = json.loads(resp.read().decode())['services']
 
         # Check that all services are running

--- a/tests/test_localstack.py
+++ b/tests/test_localstack.py
@@ -7,7 +7,7 @@ from testcontainers.localstack import LocalStackContainer
 def test_docker_run_localstack():
     config = LocalStackContainer()
     with config as localstack:
-        resp = urllib.request.urlopen('{}/health'.format(localstack.get_endpoint_override()))
+        resp = urllib.request.urlopen('{}/health'.format(localstack.get_endpoint_url()))
         services = json.loads(resp.read().decode())['services']
 
         # Check that all services are running

--- a/tests/test_localstack.py
+++ b/tests/test_localstack.py
@@ -7,7 +7,7 @@ from testcontainers.localstack import LocalStackContainer
 def test_docker_run_localstack():
     config = LocalStackContainer()
     with config as localstack:
-        resp = urllib.request.urlopen(f"{localstack.get_endpoint_override()}/health")
+        resp = urllib.request.urlopen('{}/health'.format(localstack.get_endpoint_override()))
         services = json.loads(resp.read().decode())['services']
 
         # Check that all services are running


### PR DESCRIPTION
This PR adds an equivalent to the testcontainers-java Localstack container.
This is simpler than the Java version because a simple edge port was introduced in version 0.11.0. 
This should fix #33.