### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: testcontainers-python
-on: [push]
+on:
+  - push
 
 jobs:
   build:
@@ -37,10 +38,3 @@ jobs:
           sphinx-build -nW docs docs/_build/html
           py.test -sv --cov-config .coveragerc --cov-report html:skip-covered --cov-report term:skip-covered --cov=testcontainers --tb=short tests/
           codecov
-  deploy:
-    needs: build
-    if: needs.build.result == 'success'
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Deploy to PyPi
-        run: echo deploying

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: testcontainers-python
 on:
-  - push
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup python ${{ matrix.python-version }}
@@ -25,18 +25,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+      - name: Install system requirements
+        run: |
+          sudo apt-get install -y --no-install-recommends unixodbc-dev # required for pyodbc
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          sudo apt-get -qq update
+          sudo ACCEPT_EULA=Y apt-get -y install msodbcsql17
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install wheel
           pip install -r requirements/${{ matrix.python-version }}.txt
-      - name: Install system requirements
-        run: |
-          sudo apt-get install -y --no-install-recommends unixodbc-dev # required for pyodbc
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          sudo apt-get -qq update
-          sudo ACCEPT_EULA=Y apt-get -y install msodbcsql17
       - name: Run checks
         run: |
           flake8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: testcontainers-python
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+      - name: Cache Python dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles(format('requirements/{0}.txt', matrix.python-version)) }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install -r requirements/${{ matrix.python-version }}.txt
+      - name: Install system requirements
+        run: |
+          sudo apt-get install -y --no-install-recommends unixodbc-dev # required for pyodbc
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          sudo apt-get -qq update
+          sudo ACCEPT_EULA=Y apt-get -y install msodbcsql17
+      - name: Run checks
+        run: |
+          flake8
+          sphinx-build -nW docs docs/_build/html
+          py.test -sv --cov-config .coveragerc --cov-report html:skip-covered --cov-report term:skip-covered --cov=testcontainers --tb=short tests/
+          codecov
+  deploy:
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Deploy to PyPi
+        run: echo deploying

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Cache Python dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,39 @@
+name: Upload Python packages to PyPi
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    env:
+      python-version: 3.8
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup python ${{ env.python-version }}
+        uses: actions/setup-python@v2
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles(format('requirements/{0}.txt', env.python-version)) }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements/${{ env.python-version }}.txt
+
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       python-version: 3.8
     steps:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup python ${{ env.python-version }}
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python-version }}
 
       - name: Cache Python dependencies
         uses: actions/cache@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,3 @@ notifications:
   email:
     recipients:
       - sergio_89@ukr.net
-
-deploy:
-  provider: pypi
-  user: tillahoffmann
-  password:
-    secure: "MoX7m8vD5z9PMzxyf/AW0/GJrjw75K0O5fWyzYDVK0e9fE4en4DVZQXsQ+bI5aVoOfEpAJ/wGgR4t/tsdAXolZxVyK4qM3JKfv75fHcsT1Le++S6daxruTkJY/DbkY6gj9aSMqGX9M5qumeAF4nA7VXxgQ28B0Fc65UASr4tsQ6ekqumCRpqeFMFi7IHdEm2le8J9LSxlNXOGl1QgNkC/ABPAoZiOGn/hdcugaX4BGaorwDk4if8bfonr42pizNfIkMJgCQdU0n+1KqQdm30zD1JHmVOZXryi+QZUiTLHfvpjhIlHUGr7skU0sohUwen0VEbmgezvsF303bMkfQS3zS/GlwVODv6xGFGr7Vp6sYPc3452eB9wWi08lk1evPiyiFzTb4GJR37u9bwoj22/rtePfhXvP4hZs3KXHLDn6zE2LJT+OXSRWb+UD8TqS9kHIGiR7cqRXeTnca9UyGDgAnO/Q6bYvrKcoqb94ElW4VtMvLfwqGAVWYpdD4YdLZp5FoqA+U/1MuYVV81+z8ocem5f3jnuoYfbkKFbTE0wbYozjDIeirc1Bh6ekuODakF4oKcuWdOgnO5ZEobFO45BIM5DUKkOqsfCielWdLx+A8H7v6Y04bIVwCS3NRYEsuXZoBtda3lQVYVSNGeMJUtd0TCPmzolUTTVX3K2YAe6pw="
-  # Required if building on more than one python version because each build will try to deploy
-  skip_existing: true
-  on:
-    tags: true


### PR DESCRIPTION
Closes #71

This PR adds 2 GitHub workflows:
1. `main` - regular push events
1. `pypi-release` - releasing the tagged version to PyPi

The release workflow is triggered by pushing any tag like `v*` but GitHub actions support [release events](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python#publishing-to-package-registries) which might be considered as well.

Please, let me know about your thoughts regarding this PR so I could adjust its logic.