### PR TITLE
Add Minio container support

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
--e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j,kafka]
+-e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j,kafka,minio]
 codecov>=2.1.0
 flake8
 pytest

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -21,7 +21,9 @@ cached-property==1.5.1
 cachetools==4.1.1
     # via google-auth
 certifi==2020.6.20
-    # via requests
+    # via
+    #   minio
+    #   requests
 cffi==1.14.2
     # via
     #   bcrypt
@@ -90,6 +92,8 @@ markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
+minio==7.0.4
+    # via testcontainers
 more-itertools==8.4.0
     # via pytest
 neo4j==4.1.0
@@ -205,6 +209,7 @@ toml==0.10.1
     # via pytest
 urllib3==1.25.10
     # via
+    #   minio
     #   requests
     #   selenium
 websocket-client==0.57.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setuptools.setup(
         'redis': ['redis'],
         'mssqlserver': ['pyodbc'],
         'neo4j': ['neo4j'],
-        'kafka': ['kafka-python']
+        'kafka': ['kafka-python'],
+        'minio': ['minio']
     },
     long_description_content_type="text/x-rst",
     long_description=long_description,

--- a/testcontainers/minio.py
+++ b/testcontainers/minio.py
@@ -1,0 +1,55 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from minio import Minio
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+
+class MinioContainer(DockerContainer):
+
+    def __init__(self, image="minio/minio:latest", port_to_expose=9000,
+                 access_key="adminAccessKey", secret_key="adminSecretKey", region="us-east-1", secure=False):
+        super(MinioContainer, self).__init__(image)
+        self.port_to_expose = port_to_expose
+        self.with_exposed_ports(self.port_to_expose)
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.region = region
+        self.secure = secure
+
+        self.with_env("MINIO_ACCESS_KEY", access_key)
+        self.with_env("MINIO_SECRET_KEY", secret_key)
+        self.with_env("MINIO_REGION", region)
+
+    @wait_container_is_ready()
+    def _connect(self):
+        self.get_client()
+
+    def get_client(self) -> 'Minio':
+        client = Minio(
+            "{}:{}".format(self.get_container_host_ip(), self.get_exposed_port(9000)),
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+            secure=self.secure,
+            region=self.region
+        )
+        return client
+
+    def start(self):
+        self.with_command("server /data")
+        super().start()
+        self._connect()
+        return self

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -1,0 +1,13 @@
+from testcontainers.minio import MinioContainer
+
+
+def test_docker_run_minio():
+    config = MinioContainer()
+
+    with config as minio:
+        minio_client = minio.get_client()
+        found = minio_client.bucket_exists("mybucket")
+        assert not found
+        minio_client.make_bucket("mybucket")
+        found = minio_client.bucket_exists("mybucket")
+        assert found


### PR DESCRIPTION
https://min.io/ is s3 compatible storage system.

I needed to use minio based test-containers to test some integrations. so I extended functionality accordingly.