### PR TITLE
Add compose exec_in_container method

### DIFF
--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -115,7 +115,7 @@ class DockerCompose(object):
         Executes a command in the container of one of the services.
 
         Parameters
-        -------
+        ----------
         service_name: str
             Name of the docker compose service to run the command in
         command: list[str]

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -110,6 +110,31 @@ class DockerCompose(object):
         )
         return result.stdout, result.stderr
 
+    def exec_in_container(self, service_name, command):
+        """
+        Executes a command in the container of one of the services.
+
+        Parameters
+        -------
+        service_name: str
+            Name of the docker compose service to run the command in
+        command: list[str]
+            The command to execute
+
+        Returns
+        -------
+        tuple[str, str, int]
+            stdout, stderr, return code
+        """
+        exec_cmd = self.docker_compose_command() + ['exec', '-T', service_name] + command
+        result = subprocess.run(
+            exec_cmd,
+            cwd=self.filepath,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.stdout.decode("utf-8"), result.stderr.decode("utf-8"), result.returncode
+
     def get_service_port(self, service_name, port):
         return self._get_service_info(service_name, port)[1]
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -82,3 +82,11 @@ def test_can_pass_env_params_by_env_file():
         check_env_is_set_cmd = 'docker exec tests_mysql_1 printenv | grep TEST_ASSERT_KEY'.split()
         out = subprocess.run(check_env_is_set_cmd, stdout=subprocess.PIPE)
         assert out.stdout.decode('utf-8').splitlines()[0], 'test_is_passed'
+
+
+def test_can_exec_commands():
+    with DockerCompose("tests") as compose:
+        result = compose.exec_in_container('hub', ['echo', 'my_test'])
+        assert result[0] == 'my_test\n', "The echo should be successful"
+        assert result[1] == '', "stderr should be empty"
+        assert result[2] == 0, 'The exit code should be successful'


### PR DESCRIPTION
This PR adds a method that reaches out to docker-compose to execute a command in a service container.

~~I'm open to suggestions, in particular on the return type. Having a 3 tuple undocumented seems like it may be unintuitive to understand, but there seems to already be precedent in the `get_logs` method above, and not seeing method docstrings there to document it.~~

This was an old PR and I see there is some precedence for docstrings now, added a docstring as well

Thanks