### PR TITLE
Add missing _configure to OracleDbContainer

### DIFF
--- a/testcontainers/oracle.py
+++ b/testcontainers/oracle.py
@@ -9,7 +9,7 @@ class OracleDbContainer(DbContainer):
     -------
     ::
 
-        with OracleDbContainer():
+        with OracleDbContainer() as oracle:
             e = sqlalchemy.create_engine(oracle.get_connection_url())
             result = e.execute("select 1 from dual")
     """
@@ -24,3 +24,6 @@ class OracleDbContainer(DbContainer):
             dialect="oracle", username="system", password="oracle", port=self.container_port,
             db_name="xe"
         )
+
+    def _configure(self):
+        pass


### PR DESCRIPTION
Fixes #105

Confirmed `test_docker_run_oracle` succeeds in my environment. 
<img width="514" alt="Screen Shot 2021-08-13 at 16 34 53" src="https://user-images.githubusercontent.com/6237050/129321454-5a7767ae-c693-4dd1-95e4-36560b6c8b49.png">
