### PR TITLE
Support specifying postgresql drivers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
         'mysql': ['sqlalchemy', 'pymysql'],
         'oracle': ['sqlalchemy', 'cx_Oracle'],
         'postgresql': ['sqlalchemy', 'psycopg2-binary'],
+        'postgresql-pg8000': ['sqlalchemy', 'pg8000'],
         'selenium': ['selenium'],
         'google-cloud-pubsub': ['google-cloud-pubsub < 2'],
         'mongo': ['pymongo'],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setuptools.setup(
         'mysql': ['sqlalchemy', 'pymysql'],
         'oracle': ['sqlalchemy', 'cx_Oracle'],
         'postgresql': ['sqlalchemy', 'psycopg2-binary'],
-        'postgresql-pg8000': ['sqlalchemy', 'pg8000'],
         'selenium': ['selenium'],
         'google-cloud-pubsub': ['google-cloud-pubsub < 2'],
         'mongo': ['pymongo'],

--- a/testcontainers/postgres.py
+++ b/testcontainers/postgres.py
@@ -21,15 +21,10 @@ class PostgresContainer(DbContainer):
 
     Example
     -------
-    The example spins up a Postgres database and connects to it using the (default) :code:`psycopg` driver.
+    The example spins up a Postgres database and connects to it using the :code:`psycopg` driver.
     ::
 
         with PostgresContainer("postgres:9.5") as postgres:
-            e = sqlalchemy.create_engine(postgres.get_connection_url())
-            result = e.execute("select version()")
-    
-    :: 
-        with PostgresContainer("postgres:9.5", driver="pg8000") as postgres:
             e = sqlalchemy.create_engine(postgres.get_connection_url())
             result = e.execute("select version()")
     """

--- a/testcontainers/postgres.py
+++ b/testcontainers/postgres.py
@@ -32,11 +32,11 @@ class PostgresContainer(DbContainer):
     POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "test")
     POSTGRES_DB = os.environ.get("POSTGRES_DB", "test")
 
-    def __init__(self, 
-                 image="postgres:latest", 
-                 port=5432, user=None, 
-                 password=None, 
-                 dbname=None, 
+    def __init__(self,
+                 image="postgres:latest",
+                 port=5432, user=None,
+                 password=None,
+                 dbname=None,
                  driver="psycopg2"):
         super(PostgresContainer, self).__init__(image=image)
         self.POSTGRES_USER = user or self.POSTGRES_USER

--- a/testcontainers/postgres.py
+++ b/testcontainers/postgres.py
@@ -32,7 +32,12 @@ class PostgresContainer(DbContainer):
     POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "test")
     POSTGRES_DB = os.environ.get("POSTGRES_DB", "test")
 
-    def __init__(self, image="postgres:latest", port=5432, user=None, password=None, dbname=None, driver="psycopg2"):
+    def __init__(self, 
+                 image="postgres:latest", 
+                 port=5432, user=None, 
+                 password=None, 
+                 dbname=None, 
+                 driver="psycopg2"):
         super(PostgresContainer, self).__init__(image=image)
         self.POSTGRES_USER = user or self.POSTGRES_USER
         self.POSTGRES_PASSWORD = password or self.POSTGRES_PASSWORD


### PR DESCRIPTION
I've found installing `psycopg2` driver on MacOS Big Sur being too complicated: I didn't want to install `postgres` headers nor was I able to use the `-binary` version of the package. 

I've decided to use pure-python driver, but wasn't able to do so due to the driver being hardcoded. This PR addresses the limitation by adding an optional field to the constructor to override the driver.

I've added a `postgresql-pg8000` extra preset for convenience, but I'm happy to revert if you find it redundant ( https://github.com/testcontainers/testcontainers-python/pull/156/commits/756f3e127836a12741bb629fb3c7e459b930bd94 ).