### PR TITLE
Fix readme link syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Usage within Docker (i.e. in a CI)
 
 When trying to launch a testcontainer from within a Docker container two things have to be provided:
 
-1. The container has to provide a docker client installation. Either use an image that has docker pre-installed (e.g. the [official docker images](https://hub.docker.com/_/docker)) or install the client from within the `Dockerfile` specification.
+1. The container has to provide a docker client installation. Either use an image that has docker pre-installed (e.g. the `official docker images <https://hub.docker.com/_/docker>`_) or install the client from within the `Dockerfile` specification.
 2. The container has to have access to the docker daemon which can be achieved by mounting `/var/run/docker.sock` or setting the `DOCKER_HOST` environment variable as part of your `docker run` command.
 
 


### PR DESCRIPTION
Update a lingering link in the readme from markdown syntax to rst.