### PR TITLE
Move `deprecated` decorator from `__init__` to class definition

### DIFF
--- a/testcontainers/core/generic.py
+++ b/testcontainers/core/generic.py
@@ -57,4 +57,4 @@ class DbContainer(DockerContainer):
 @deprecated(details="Use `DockerContainer`.")
 class GenericContainer(DockerContainer):
     def __init__(self, image):
-        super(GenericContainer, self).__init__(image)
+        super().__init__(image)

--- a/testcontainers/core/generic.py
+++ b/testcontainers/core/generic.py
@@ -54,7 +54,7 @@ class DbContainer(DockerContainer):
         raise NotImplementedError
 
 
+@deprecated(details="Use `DockerContainer`.")
 class GenericContainer(DockerContainer):
-    @deprecated(details="Use `DockerContainer`.")
     def __init__(self, image):
         super(GenericContainer, self).__init__(image)

--- a/testcontainers/general.py
+++ b/testcontainers/general.py
@@ -14,8 +14,8 @@ from deprecation import deprecated
 from testcontainers.core.container import DockerContainer
 
 
+@deprecated(details="Use `DockerContainer`.")
 class TestContainer(DockerContainer):
-    @deprecated(details="Use `DockerContainer`.")
     def __init__(self, image, port_to_expose=None):
         super(TestContainer, self).__init__(image)
         if port_to_expose:

--- a/testcontainers/general.py
+++ b/testcontainers/general.py
@@ -17,7 +17,7 @@ from testcontainers.core.container import DockerContainer
 @deprecated(details="Use `DockerContainer`.")
 class TestContainer(DockerContainer):
     def __init__(self, image, port_to_expose=None):
-        super(TestContainer, self).__init__(image)
+        super().__init__(image)
         if port_to_expose:
             self.port_to_expose = port_to_expose
             self.with_exposed_ports(self.port_to_expose)

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -62,6 +62,7 @@ class MySqlContainer(DbContainer):
                                               port=self.port_to_expose)
 
 
+@deprecated(details="Use `MySqlContainer` with 'mariadb:latest' image.")
 class MariaDbContainer(MySqlContainer):
     """
     Maria database container, a commercially-supported fork of MySql.
@@ -74,6 +75,5 @@ class MariaDbContainer(MySqlContainer):
             e = sqlalchemy.create_engine(mariadb.get_connection_url())
             result = e.execute("select version()")
     """
-    @deprecated(details="Use `MySqlContainer` with 'mariadb:latest' image.")
     def __init__(self, image="mariadb:latest", **kwargs):
         super(MariaDbContainer, self).__init__(image, **kwargs)

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -76,4 +76,4 @@ class MariaDbContainer(MySqlContainer):
             result = e.execute("select version()")
     """
     def __init__(self, image="mariadb:latest", **kwargs):
-        super(MariaDbContainer, self).__init__(image, **kwargs)
+        super().__init__(image, **kwargs)

--- a/testcontainers/nginx.py
+++ b/testcontainers/nginx.py
@@ -17,6 +17,6 @@ from testcontainers.core.container import DockerContainer
 @deprecated(details="Use `DockerContainer` with 'nginx:latest' image and expose port 80.")
 class NginxContainer(DockerContainer):
     def __init__(self, image="nginx:latest", port_to_expose=80):
-        super(NginxContainer, self).__init__(image)
+        super().__init__(image)
         self.port_to_expose = port_to_expose
         self.with_exposed_ports(self.port_to_expose)

--- a/testcontainers/nginx.py
+++ b/testcontainers/nginx.py
@@ -14,8 +14,8 @@ from deprecation import deprecated
 from testcontainers.core.container import DockerContainer
 
 
+@deprecated(details="Use `DockerContainer` with 'nginx:latest' image and expose port 80.")
 class NginxContainer(DockerContainer):
-    @deprecated(details="Use `DockerContainer` with 'nginx:latest' image and expose port 80.")
     def __init__(self, image="nginx:latest", port_to_expose=80):
         super(NginxContainer, self).__init__(image)
         self.port_to_expose = port_to_expose


### PR DESCRIPTION
Improve deprecation messages from:
```DeprecatedWarning: __init__ is deprecated. Use `DockerContainer`.```
to:
 ```DeprecatedWarning: TestContainer is deprecated. Use `DockerContainer`.```