### PR TITLE
Fix deprecation warning message for `ElasticsearchContainer`

### DIFF
--- a/testcontainers/elasticsearch.py
+++ b/testcontainers/elasticsearch.py
@@ -52,5 +52,7 @@ class ElasticSearchContainer(DockerContainer):
         return self
 
 
-ElasticsearchContainer = deprecated(details='Use `ElasticSearchContainer` with a capital S instead '
-                                    'of `ElasticsearchContainer`.')(ElasticSearchContainer)
+@deprecated(details='Use `ElasticSearchContainer` with a capital S instead '
+                    'of `ElasticsearchContainer`.')
+class ElasticsearchContainer(ElasticSearchContainer):
+    pass


### PR DESCRIPTION
When I use `ElasticsearchContainer` class I get a "DeprecatedWarning: Elastic**S**earchContainer is deprecated" message which is wrong. This PR fixes this.