### PR TITLE
Add support for asyncio

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 codecov>=2.1.0
 flake8
 pytest
+pytest-asyncio
 pytest-cov
 sphinx
 docker<4.3.0

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -108,6 +108,7 @@ protobuf==3.13.0
     #   google-api-core
     #   googleapis-common-protos
 psycopg2-binary==2.8.5
+asyncpg==0.25.0
     # via testcontainers
 py==1.9.0
     # via pytest
@@ -143,6 +144,10 @@ pytest==6.0.1
     # via
     #   -r requirements.in
     #   pytest-cov
+pytest-asyncio==0.16.0
+    # via
+    #   -r requirements.in
+    #   pytest-asyncio
 python-dotenv==0.14.0
     # via docker-compose
 pytz==2020.1
@@ -197,8 +202,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy==1.3.18
+sqlalchemy==1.4.28
     # via testcontainers
+    # via pytest-asyncio
 texttable==1.6.2
     # via docker-compose
 toml==0.10.1

--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -8,6 +8,121 @@ from testcontainers.core.utils import setup_logger, inside_container
 logger = setup_logger(__name__)
 
 
+class AsyncDockerContainer(object):
+    def __init__(self, image, **kwargs):
+        self.env = {}
+        self.ports = {}
+        self.volumes = {}
+        self.image = image
+        self._docker = DockerClient()
+        self._container = None
+        self._command = None
+        self._name = None
+        self._kwargs = kwargs
+
+    def with_env(self, key: str, value: str) -> 'AsyncDockerContainer':
+        self.env[key] = value
+        return self
+
+    def with_bind_ports(self, container: int,
+                        host: int = None) -> 'AsyncDockerContainer':
+        self.ports[container] = host
+        return self
+
+    def with_exposed_ports(self, *ports) -> 'AsyncDockerContainer':
+        for port in list(ports):
+            self.ports[port] = None
+        return self
+
+    @deprecated(details='Use `with_kwargs`.')
+    def with_kargs(self, **kargs) -> 'AsyncDockerContainer':
+        return self.with_kwargs(**kargs)
+
+    def with_kwargs(self, **kwargs) -> 'AsyncDockerContainer':
+        self._kwargs = kwargs
+        return self
+
+    async def start(self):
+        logger.info("Pulling image %s", self.image)
+        docker_client = self.get_docker_client()
+        self._container = docker_client.run(self.image,
+                                            command=self._command,
+                                            detach=True,
+                                            environment=self.env,
+                                            ports=self.ports,
+                                            name=self._name,
+                                            volumes=self.volumes,
+                                            **self._kwargs
+                                            )
+        logger.info("Container started: %s", self._container.short_id)
+        return self
+
+    async def stop(self, force=True, delete_volume=True):
+        self.get_wrapped_container().remove(force=force, v=delete_volume)
+
+    async def __aenter__(self):
+        return await self.start()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()
+
+    def get_container_host_ip(self) -> str:
+        # infer from docker host
+        host = self.get_docker_client().host()
+        if not host:
+            return "localhost"
+
+        # check testcontainers itself runs inside docker container
+        if inside_container():
+            # If newly spawned container's gateway IP address from the docker
+            # "bridge" network is equal to detected host address, we should use
+            # container IP address, otherwise fall back to detected host
+            # address. Even it's inside container, we need to double check,
+            # because docker host might be set to docker:dind, usually in CI/CD environment
+            gateway_ip = self.get_docker_client().gateway_ip(self._container.id)
+
+            if gateway_ip == host:
+                return self.get_docker_client().bridge_ip(self._container.id)
+            return gateway_ip
+        return host
+
+    def get_exposed_port(self, port) -> str:
+        mapped_port = self.get_docker_client().port(self._container.id, port)
+        if inside_container():
+            gateway_ip = self.get_docker_client().gateway_ip(self._container.id)
+            host = self.get_docker_client().host()
+
+            if gateway_ip == host:
+                return port
+        return mapped_port
+
+    def with_command(self, command: str) -> 'AsyncDockerContainer':
+        self._command = command
+        return self
+
+    def with_name(self, name: str) -> 'AsyncDockerContainer':
+        self._name = name
+        return self
+
+    def with_volume_mapping(self, host: str, container: str,
+                            mode: str = 'ro') -> 'AsyncDockerContainer':
+        # '/home/user1/': {'bind': '/mnt/vol2', 'mode': 'rw'}
+        mapping = {'bind': container, 'mode': mode}
+        self.volumes[host] = mapping
+        return self
+
+    def get_wrapped_container(self) -> Container:
+        return self._container
+
+    def get_docker_client(self) -> DockerClient:
+        return self._docker
+
+    def exec(self, command):
+        if not self._container:
+            raise ContainerStartException("Container should be started before")
+        return self.get_wrapped_container().exec_run(command)
+
+
 class DockerContainer(object):
     def __init__(self, image, **kwargs):
         self.env = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from asyncio import get_event_loop
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = get_event_loop()
+    yield loop
+    loop.close()

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -2,6 +2,8 @@ import pytest
 import sqlalchemy
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure
+from sqlalchemy.ext.asyncio.engine import create_async_engine
+from sqlalchemy import text
 
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for
@@ -10,7 +12,7 @@ from testcontainers.mssql import SqlServerContainer
 from testcontainers.mysql import MySqlContainer
 from testcontainers.neo4j import Neo4jContainer
 from testcontainers.oracle import OracleDbContainer
-from testcontainers.postgres import PostgresContainer
+from testcontainers.postgres import PostgresContainer, AsyncPostgresContainer
 
 
 def test_docker_run_mysql():
@@ -29,6 +31,17 @@ def test_docker_run_postgress():
         result = e.execute("select version()")
         for row in result:
             print("server version:", row[0])
+
+
+@pytest.mark.asyncio
+async def test_docker_run_postgres():
+    postgres_container = AsyncPostgresContainer("postgres:9.5")
+    async with postgres_container as postgres:
+        e = create_async_engine(postgres.get_connection_url())
+        async with e.begin() as conn:
+            result = await conn.execute(text("select version()"))
+            for row in result:
+                print("server version:", row[0])
 
 
 def test_docker_run_greenplum():


### PR DESCRIPTION
This PR contains the core code prepared for asynchronous processing in Python.

Asynchronous processing using the asyncio module is supported from SQLAlchemy version 1.4.
(https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html)

So, in order to use these asynchronous modules in testcontainers, we make a PR request for the code that supports these modules.

In addition to PostgreSQL, other relational DB drivers can also support it, and a parameter has been added to the function to select Dialect in the existing code.
(Python uses several DB driver, so I don't think it's good to hardcode a specific driver #140)