### PR TITLE
Make the GCP pubsub container work

### DIFF
--- a/testcontainers/google/pubsub.py
+++ b/testcontainers/google/pubsub.py
@@ -13,6 +13,11 @@
 
 from ..core.container import DockerContainer
 
+from google.cloud import pubsub
+from google.auth import credentials
+
+import os
+
 
 class PubSubContainer(DockerContainer):
     """
@@ -38,27 +43,31 @@ class PubSubContainer(DockerContainer):
         super(PubSubContainer, self).__init__(image=image)
         self.project = project
         self.port = port
-        self.with_exposed_ports(self.port)
-        self.with_command("gcloud beta emulators pubsub start --project="
-                          "{project} --host-port=0.0.0.0:{port}".format(
-                              project=self.project, port=self.port,
-                          ))
+        self.with_bind_ports(self.port, self.port)
+        # self.with_exposed_ports(self.port)
+        self.with_command(
+            "gcloud beta emulators pubsub start --project={project} --host-port=0.0.0.0:{port}".format(
+                project=self.project, port=self.port
+            ))
+
+    def __enter__(self):
+        os.environ['PUBSUB_EMULATOR_HOST'] = '0.0.0.0:{port}'.format(port=self.port)
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.unsetenv('PUBSUB_EMULATOR_HOST')
+        super().__exit__(exc_type, exc_val, exc_tb)
 
     def get_pubsub_emulator_host(self):
         return "{host}:{port}".format(host=self.get_container_host_ip(),
                                       port=self.get_exposed_port(self.port))
 
-    def _get_channel(self, channel=None):
-        if channel is None:
-            import grpc
-            return grpc.insecure_channel(target=self.get_pubsub_emulator_host())
-
     def get_publisher_client(self, **kwargs):
-        from google.cloud import pubsub
-        kwargs['channel'] = self._get_channel(kwargs.get('channel'))
+        kwargs['client_options'] = dict(api_endpoint=self.get_pubsub_emulator_host())
+        # kwargs['credentials'] = credentials.AnonymousCredentials()
         return pubsub.PublisherClient(**kwargs)
 
     def get_subscriber_client(self, **kwargs):
-        from google.cloud import pubsub
-        kwargs['channel'] = self._get_channel(kwargs.get('channel'))
+        kwargs['client_options'] = dict(api_endpoint=self.get_pubsub_emulator_host())
+        # kwargs['credentials'] = credentials.AnonymousCredentials()
         return pubsub.SubscriberClient(**kwargs)

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -4,25 +4,28 @@ from queue import Queue
 
 
 def test_pubsub_container():
-    with PubSubContainer() as pubsub:
+    with PubSubContainer(project="local-test") as pubsub:
+
         wait_for_logs(pubsub, r"Server started, listening on \d+", timeout=10)
+
         # Create a new topic
         publisher = pubsub.get_publisher_client()
         topic_path = publisher.topic_path(pubsub.project, "my-topic")
-        publisher.create_topic(topic_path)
+
+        # publisher.create_topic(name=topic_path)
+        publisher.create_topic(request={"name": topic_path})
 
         # Create a subscription
         subscriber = pubsub.get_subscriber_client()
-        subscription_path = subscriber.subscription_path(pubsub.project,
-                                                         "my-subscription")
-        subscriber.create_subscription(subscription_path, topic_path)
+        subscription_path = subscriber.subscription_path(pubsub.project, "my-subscription")
+        subscriber.create_subscription(name=subscription_path, topic=topic_path)
 
         # Publish a message
-        publisher.publish(topic_path, b"Hello world!")
+        publisher.publish(topic=topic_path, data=b"Hello world!")
 
         # Receive the message
         queue = Queue()
-        subscriber.subscribe(subscription_path, queue.put)
+        subscriber.subscribe(subscription=subscription_path, callback=queue.put)
         message = queue.get(timeout=1)
         assert message.data == b"Hello world!"
         message.ack()


### PR DESCRIPTION
Changes

1. Replace ``with_exposed_ports`` with ``with_bind_ports``
2. Modify the context manager to set and unset environment variable as mentioned in https://cloud.google.com/pubsub/docs/emulator#env
3. Update the test

