### PR TITLE
Reduce log level to prevent log file pollution

### DIFF
--- a/testcontainers/core/waiting_utils.py
+++ b/testcontainers/core/waiting_utils.py
@@ -48,7 +48,7 @@ def wait_container_is_ready(*transient_exceptions):
             try:
                 return wrapped(*args, **kwargs)
             except transient_exceptions as e:
-                logger.info('container is not yet ready: %s', traceback.format_exc())
+                logger.debug('container is not yet ready: %s', traceback.format_exc())
                 time.sleep(config.SLEEP_TIME)
                 exception = e
         raise TimeoutException(


### PR DESCRIPTION
Fixes #192

This PR reduces the log level for exceptions which occur while waiting for the Kafka broker to come up.
@tillahoffmann recommend this solution.