### PR TITLE
added logging of attempt no. while attempting to connect to container

### DIFF
--- a/testcontainers/core/waiting_utils.py
+++ b/testcontainers/core/waiting_utils.py
@@ -48,8 +48,7 @@ def wait_container_is_ready(*transient_exceptions):
             try:
                 return wrapped(*args, **kwargs)
             except transient_exceptions as e:
-                logger.info(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' failed, retrying...")
-                logger.debug('container is not yet ready: %s', traceback.format_exc())
+                logger.debug(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' failed: {traceback.format_exc()}")
                 time.sleep(config.SLEEP_TIME)
                 exception = e
         raise TimeoutException(

--- a/testcontainers/core/waiting_utils.py
+++ b/testcontainers/core/waiting_utils.py
@@ -48,7 +48,8 @@ def wait_container_is_ready(*transient_exceptions):
             try:
                 return wrapped(*args, **kwargs)
             except transient_exceptions as e:
-                logger.debug(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' failed: {traceback.format_exc()}")
+                logger.debug(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' "
+                             f"failed: {traceback.format_exc()}")
                 time.sleep(config.SLEEP_TIME)
                 exception = e
         raise TimeoutException(

--- a/testcontainers/core/waiting_utils.py
+++ b/testcontainers/core/waiting_utils.py
@@ -44,10 +44,11 @@ def wait_container_is_ready(*transient_exceptions):
     def wrapper(wrapped, instance, args, kwargs):
         exception = None
         logger.info("Waiting to be ready...")
-        for _ in range(config.MAX_TRIES):
+        for attempt_no in range(config.MAX_TRIES):
             try:
                 return wrapped(*args, **kwargs)
             except transient_exceptions as e:
+                logger.info(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' failed, retrying...")
                 logger.debug('container is not yet ready: %s', traceback.format_exc())
                 time.sleep(config.SLEEP_TIME)
                 exception = e


### PR DESCRIPTION
Minor change to logging while caught in the "connection retry loop" as per [this comment](https://github.com/testcontainers/testcontainers-python/issues/206#issuecomment-1103026320) in [this issue](https://github.com/testcontainers/testcontainers-python/issues/206). Feel free to approve or reject at your leisure.