### PR TITLE
Add support for pg8000 postgres driver

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 -e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j,kafka,rabbitmq,clickhouse]
 codecov>=2.1.0
+cryptography<37
 flake8<3.8.0  # 3.8.0 adds a dependency on importlib-metadata which conflicts with other packages.
 pg8000
 pytest

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 -e file:.[docker-compose,mysql,oracle,postgresql,selenium,google-cloud-pubsub,mongo,redis,mssqlserver,neo4j,kafka,rabbitmq,clickhouse]
 codecov>=2.1.0
 flake8<3.8.0  # 3.8.0 adds a dependency on importlib-metadata which conflicts with other packages.
+pg8000
 pytest
 pytest-cov
 sphinx

--- a/requirements/3.6.txt
+++ b/requirements/3.6.txt
@@ -8,19 +8,21 @@
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
+asn1crypto==1.5.1
+    # via scramp
 async-timeout==4.0.2
     # via redis
 attrs==21.4.0
     # via
     #   jsonschema
     #   pytest
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 backports.zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via paramiko
 cached-property==1.5.2
     # via docker-compose
@@ -43,7 +45,7 @@ coverage[toml]==6.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==36.0.2
+cryptography==37.0.1
     # via paramiko
 cx-oracle==8.3.0
     # via testcontainers
@@ -69,9 +71,9 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements.in
-google-api-core[grpc]==2.7.1
+google-api-core[grpc]==2.7.3
     # via google-cloud-pubsub
-google-auth==2.6.3
+google-auth==2.6.6
     # via google-api-core
 google-cloud-pubsub==1.7.1
     # via testcontainers
@@ -118,7 +120,7 @@ markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-neo4j==4.4.2
+neo4j==4.4.3
     # via testcontainers
 packaging==21.3
     # via
@@ -126,9 +128,11 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
-paramiko==2.10.3
+paramiko==2.10.4
     # via docker
-pika==1.2.0
+pg8000==1.26.0
+    # via testcontainers
+pika==1.2.1
     # via testcontainers
 pluggy==1.0.0
     # via pytest
@@ -153,11 +157,11 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via sphinx
-pymongo==4.1.0
+pymongo==4.1.1
     # via testcontainers
-pymssql==2.2.4
+pymssql==2.2.5
     # via testcontainers
 pymysql==1.0.2
     # via testcontainers
@@ -195,11 +199,12 @@ requests==2.27.1
     #   sphinx
 rsa==4.8
     # via google-auth
+scramp==1.4.1
+    # via pg8000
 selenium==3.141.0
     # via testcontainers
 six==1.16.0
     # via
-    #   bcrypt
     #   dockerpty
     #   google-auth
     #   grpcio
@@ -222,7 +227,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.35
+sqlalchemy==1.4.36
     # via testcontainers
 texttable==1.6.4
     # via docker-compose
@@ -247,7 +252,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   deprecated
     #   testcontainers

--- a/requirements/3.6.txt
+++ b/requirements/3.6.txt
@@ -45,8 +45,10 @@ coverage[toml]==6.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
-    # via paramiko
+cryptography==36.0.2
+    # via
+    #   -r requirements.in
+    #   paramiko
 cx-oracle==8.3.0
     # via testcontainers
 deprecated==1.2.13

--- a/requirements/3.6.txt
+++ b/requirements/3.6.txt
@@ -45,7 +45,7 @@ coverage[toml]==6.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.1
+cryptography==37.0.2
     # via paramiko
 cx-oracle==8.3.0
     # via testcontainers
@@ -86,13 +86,13 @@ greenlet==1.1.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.4
     # via google-cloud-pubsub
-grpcio==1.44.0
+grpcio==1.46.0
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.44.0
+grpcio-status==1.46.0
     # via google-api-core
 idna==3.3
     # via requests
@@ -131,7 +131,7 @@ packaging==21.3
 paramiko==2.10.4
     # via docker
 pg8000==1.26.0
-    # via testcontainers
+    # via -r requirements.in
 pika==1.2.1
     # via testcontainers
 pluggy==1.0.0

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -53,8 +53,9 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
+cryptography==36.0.2
     # via
+    #   -r requirements.in
     #   paramiko
     #   pyopenssl
     #   urllib3

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -53,7 +53,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.1
+cryptography==37.0.2
     # via
     #   paramiko
     #   pyopenssl
@@ -97,13 +97,13 @@ greenlet==1.1.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.4
     # via google-cloud-pubsub
-grpcio==1.44.0
+grpcio==1.46.0
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.44.0
+grpcio-status==1.46.0
     # via google-api-core
 h11==0.13.0
     # via wsproto
@@ -147,7 +147,7 @@ packaging==21.3
 paramiko==2.10.4
     # via docker
 pg8000==1.26.1
-    # via testcontainers
+    # via -r requirements.in
 pika==1.2.1
     # via testcontainers
 pluggy==1.0.0

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
+asn1crypto==1.5.1
+    # via scramp
 async-generator==1.10
     # via
     #   trio
@@ -20,13 +22,13 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via paramiko
 cached-property==1.5.2
     # via docker-compose
@@ -51,7 +53,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==36.0.2
+cryptography==37.0.1
     # via
     #   paramiko
     #   pyopenssl
@@ -80,9 +82,9 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements.in
-google-api-core[grpc]==2.7.1
+google-api-core[grpc]==2.7.3
     # via google-cloud-pubsub
-google-auth==2.6.3
+google-auth==2.6.6
     # via google-api-core
 google-cloud-pubsub==1.7.1
     # via testcontainers
@@ -122,7 +124,7 @@ importlib-metadata==4.11.3
     #   sqlalchemy
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
@@ -132,7 +134,7 @@ markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-neo4j==4.4.2
+neo4j==4.4.3
     # via testcontainers
 outcome==1.1.0
     # via trio
@@ -142,13 +144,15 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
-paramiko==2.10.3
+paramiko==2.10.4
     # via docker
-pika==1.2.0
+pg8000==1.26.1
+    # via testcontainers
+pika==1.2.1
     # via testcontainers
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.0
+protobuf==3.20.1
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -169,11 +173,11 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via sphinx
-pymongo==4.1.0
+pymongo==4.1.1
     # via testcontainers
-pymssql==2.2.4
+pymssql==2.2.5
     # via testcontainers
 pymysql==1.0.2
     # via testcontainers
@@ -187,7 +191,7 @@ pyrsistent==0.18.1
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -215,11 +219,12 @@ requests==2.27.1
     #   sphinx
 rsa==4.8
     # via google-auth
+scramp==1.4.1
+    # via pg8000
 selenium==4.1.3
     # via testcontainers
 six==1.16.0
     # via
-    #   bcrypt
     #   dockerpty
     #   google-auth
     #   grpcio
@@ -246,7 +251,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.35
+sqlalchemy==1.4.36
     # via testcontainers
 texttable==1.6.4
     # via docker-compose
@@ -260,7 +265,7 @@ trio==0.20.0
     #   trio-websocket
 trio-websocket==0.9.2
     # via selenium
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   async-timeout
     #   h11
@@ -278,7 +283,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   deprecated
     #   testcontainers

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -51,8 +51,9 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
+cryptography==36.0.2
     # via
+    #   -r requirements.in
     #   paramiko
     #   pyopenssl
     #   urllib3

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -51,7 +51,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.1
+cryptography==37.0.2
     # via
     #   paramiko
     #   pyopenssl
@@ -95,13 +95,13 @@ greenlet==1.1.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.4
     # via google-cloud-pubsub
-grpcio==1.44.0
+grpcio==1.46.0
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.44.0
+grpcio-status==1.46.0
     # via google-api-core
 h11==0.13.0
     # via wsproto
@@ -139,7 +139,7 @@ packaging==21.3
 paramiko==2.10.4
     # via docker
 pg8000==1.26.1
-    # via testcontainers
+    # via -r requirements.in
 pika==1.2.1
     # via testcontainers
 pluggy==1.0.0

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
+asn1crypto==1.5.1
+    # via scramp
 async-generator==1.10
     # via
     #   trio
@@ -20,13 +22,13 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via paramiko
 cachetools==5.0.0
     # via google-auth
@@ -49,7 +51,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==36.0.2
+cryptography==37.0.1
     # via
     #   paramiko
     #   pyopenssl
@@ -78,9 +80,9 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements.in
-google-api-core[grpc]==2.7.1
+google-api-core[grpc]==2.7.3
     # via google-cloud-pubsub
-google-auth==2.6.3
+google-auth==2.6.6
     # via google-api-core
 google-cloud-pubsub==1.7.1
     # via testcontainers
@@ -114,7 +116,7 @@ importlib-metadata==4.11.3
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
@@ -124,7 +126,7 @@ markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-neo4j==4.4.2
+neo4j==4.4.3
     # via testcontainers
 outcome==1.1.0
     # via trio
@@ -134,13 +136,15 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
-paramiko==2.10.3
+paramiko==2.10.4
     # via docker
-pika==1.2.0
+pg8000==1.26.1
+    # via testcontainers
+pika==1.2.1
     # via testcontainers
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.0
+protobuf==3.20.1
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -161,11 +165,11 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via sphinx
-pymongo==4.1.0
+pymongo==4.1.1
     # via testcontainers
-pymssql==2.2.4
+pymssql==2.2.5
     # via testcontainers
 pymysql==1.0.2
     # via testcontainers
@@ -179,7 +183,7 @@ pyrsistent==0.18.1
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -207,11 +211,12 @@ requests==2.27.1
     #   sphinx
 rsa==4.8
     # via google-auth
+scramp==1.4.1
+    # via pg8000
 selenium==4.1.3
     # via testcontainers
 six==1.16.0
     # via
-    #   bcrypt
     #   dockerpty
     #   google-auth
     #   grpcio
@@ -238,7 +243,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.35
+sqlalchemy==1.4.36
     # via testcontainers
 texttable==1.6.4
     # via docker-compose
@@ -264,7 +269,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   deprecated
     #   testcontainers

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
+asn1crypto==1.5.1
+    # via scramp
 async-generator==1.10
     # via
     #   trio
@@ -20,9 +22,9 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
-babel==2.9.1
+babel==2.10.1
     # via sphinx
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via paramiko
 cachetools==5.0.0
     # via google-auth
@@ -45,7 +47,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==36.0.2
+cryptography==37.0.1
     # via
     #   paramiko
     #   pyopenssl
@@ -74,9 +76,9 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements.in
-google-api-core[grpc]==2.7.1
+google-api-core[grpc]==2.7.3
     # via google-cloud-pubsub
-google-auth==2.6.3
+google-auth==2.6.6
     # via google-api-core
 google-cloud-pubsub==1.7.1
     # via testcontainers
@@ -110,7 +112,7 @@ importlib-metadata==4.11.3
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
 jsonschema==3.2.0
     # via docker-compose
@@ -120,7 +122,7 @@ markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-neo4j==4.4.2
+neo4j==4.4.3
     # via testcontainers
 outcome==1.1.0
     # via trio
@@ -130,13 +132,15 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
-paramiko==2.10.3
+paramiko==2.10.4
     # via docker
-pika==1.2.0
+pg8000==1.26.1
+    # via testcontainers
+pika==1.2.1
     # via testcontainers
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.0
+protobuf==3.20.1
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -157,11 +161,11 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via sphinx
-pymongo==4.1.0
+pymongo==4.1.1
     # via testcontainers
-pymssql==2.2.4
+pymssql==2.2.5
     # via testcontainers
 pymysql==1.0.2
     # via testcontainers
@@ -175,7 +179,7 @@ pyrsistent==0.18.1
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -203,11 +207,12 @@ requests==2.27.1
     #   sphinx
 rsa==4.8
     # via google-auth
+scramp==1.4.1
+    # via pg8000
 selenium==4.1.3
     # via testcontainers
 six==1.16.0
     # via
-    #   bcrypt
     #   dockerpty
     #   google-auth
     #   grpcio
@@ -234,7 +239,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.35
+sqlalchemy==1.4.36
     # via testcontainers
 texttable==1.6.4
     # via docker-compose
@@ -260,7 +265,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   deprecated
     #   testcontainers

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -47,8 +47,9 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
+cryptography==36.0.2
     # via
+    #   -r requirements.in
     #   paramiko
     #   pyopenssl
     #   urllib3

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -47,7 +47,7 @@ coverage[toml]==6.3.2
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.1
+cryptography==37.0.2
     # via
     #   paramiko
     #   pyopenssl
@@ -91,13 +91,13 @@ greenlet==1.1.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.4
     # via google-cloud-pubsub
-grpcio==1.44.0
+grpcio==1.46.0
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.44.0
+grpcio-status==1.46.0
     # via google-api-core
 h11==0.13.0
     # via wsproto
@@ -135,7 +135,7 @@ packaging==21.3
 paramiko==2.10.4
     # via docker
 pg8000==1.26.1
-    # via testcontainers
+    # via -r requirements.in
 pika==1.2.1
     # via testcontainers
 pluggy==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         'docker-compose': ['docker-compose'],
         'mysql': ['sqlalchemy', 'pymysql'],
         'oracle': ['sqlalchemy', 'cx_Oracle'],
-        'postgresql': ['sqlalchemy', 'psycopg2-binary', 'pg8000'],
+        'postgresql': ['sqlalchemy', 'psycopg2-binary'],
         'selenium': ['selenium'],
         'google-cloud-pubsub': ['google-cloud-pubsub < 2'],
         'mongo': ['pymongo'],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         'docker-compose': ['docker-compose'],
         'mysql': ['sqlalchemy', 'pymysql'],
         'oracle': ['sqlalchemy', 'cx_Oracle'],
-        'postgresql': ['sqlalchemy', 'psycopg2-binary'],
+        'postgresql': ['sqlalchemy', 'psycopg2-binary', 'pg8000'],
         'selenium': ['selenium'],
         'google-cloud-pubsub': ['google-cloud-pubsub < 2'],
         'mongo': ['pymongo'],

--- a/testcontainers/core/generic.py
+++ b/testcontainers/core/generic.py
@@ -16,8 +16,8 @@ from testcontainers.core.waiting_utils import wait_container_is_ready
 from deprecation import deprecated
 ADDITIONAL_TRANSIENT_ERRORS = []
 try:
-    from sqlalchemy.exc import OperationalError
-    ADDITIONAL_TRANSIENT_ERRORS.append(OperationalError)
+    from sqlalchemy.exc import DBAPIError
+    ADDITIONAL_TRANSIENT_ERRORS.append(DBAPIError)
 except ImportError:
     pass
 

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -35,6 +35,13 @@ def test_docker_run_postgres():
             print("server version:", row[0])
 
 
+def test_docker_run_postgres_with_driver_pg8000():
+    postgres_container = PostgresContainer("postgres:9.5", driver="pg8000")
+    with postgres_container as postgres:
+        e = sqlalchemy.create_engine(postgres.get_connection_url())
+        e.execute("select 1=1")
+
+
 @pytest.mark.skip(reason='test does not verify additional code over `test_docker_run_postgres`')
 def test_docker_run_greenplum():
     container = PostgresContainer("datagrip/greenplum:6.8", user="guest", password="guest",


### PR DESCRIPTION
Fix too specific transient exception

`OperationalError` inherits from `DBAPIError`.
`pg8000` driver raises `InterfaceError` which also inherits form `DBAPIError`

```
sqlalchemy.exc.InterfaceError: (pg8000.exceptions.InterfaceError) network error on read
(Background on this error at: https://sqlalche.me/e/14/rvf5)
```