### PR TITLE
[fix/oracle]: service name is XE, not xe.

### DIFF
--- a/testcontainers/oracle.py
+++ b/testcontainers/oracle.py
@@ -22,7 +22,7 @@ class OracleDbContainer(DbContainer):
     def get_connection_url(self):
         return super()._create_connection_url(
             dialect="oracle", username="system", password="oracle", port=self.container_port,
-            db_name="xe"
+            db_name="XE"
         )
 
     def _configure(self):


### PR DESCRIPTION
testing always return "ORA-12514: TNS:listener does not currently know of service requested in connect
descriptor"
it is because the service is names  "XE".

see this command:
```bash
root@a09a1d6ea6c3:/# su - oracle
oracle@a09a1d6ea6c3:~$ lsnrctl status

LSNRCTL for Linux: Version 11.2.0.2.0 - Production on 11-MAY-2022 11:41:15

Copyright (c) 1991, 2011, Oracle.  All rights reserved.

Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=IPC)(KEY=EXTPROC_FOR_XE)))
STATUS of the LISTENER
------------------------
Alias                     LISTENER
Version                   TNSLSNR for Linux: Version 11.2.0.2.0 - Production
Start Date                11-MAY-2022 11:40:49
Uptime                    0 days 0 hr. 0 min. 26 sec
Trace Level               off
Security                  ON: Local OS Authentication
SNMP                      OFF
Default Service           XE
Listener Parameter File   /u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora
Listener Log File         /u01/app/oracle/diag/tnslsnr/a09a1d6ea6c3/listener/alert/log.xml
Listening Endpoints Summary...
  (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC_FOR_XE)))
  (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=a09a1d6ea6c3)(PORT=1521)))
  (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=a09a1d6ea6c3)(PORT=8080))(Presentation=HTTP)(Session=RAW))
Services Summary...
Service "PLSExtProc" has 1 instance(s).
  Instance "PLSExtProc", status UNKNOWN, has 1 handler(s) for this service...
Service "XE" has 1 instance(s).
  Instance "XE", status READY, has 1 handler(s) for this service...
Service "XEXDB" has 1 instance(s).
  Instance "XE", status READY, has 1 handler(s) for this service...
The command completed successfully
oracle@a09a1d6ea6c3:~$
```

the service name is "XE", not "xe".
so if you want to connect using (in testcontainers/core/generic.py)
line 48
```python
        if db_name:
            url += '/' + db_name
```
it means that you want to connect using a service name, so get_connection_url must return "XE" as service_name

if it were : 
```python
        if db_name:
            url += ': + db_name
```
then you could use "xe" (the db_name). but it is not the case