### PR TITLE
Fix None/True/False handling in Arango.

### DIFF
--- a/testcontainers/arangodb.py
+++ b/testcontainers/arangodb.py
@@ -42,10 +42,10 @@ class ArangoDbContainer(DbContainer):
             arango_root_password: Start ArangoDB with the given password for root. Defaults to the
                 environment variable `ARANGO_ROOT_PASSWORD` if `None`.
             arango_no_auth: Disable authentication completely. Defaults to the environment variable
-                `ARANGO_NO_AUTH` or `False` if the environment variable is not available.
+                `ARANGO_NO_AUTH` if `None` or `False` if the environment variable is not available.
             arango_random_root_password: Let ArangoDB generate a random root password. Defaults to
-                the environment variable `ARANGO_NO_AUTH` or `False` if the environment variable is
-                not available.
+                the environment variable `ARANGO_NO_AUTH` if `None` or `False` if the environment
+                variable is not available.
         """
         super().__init__(image=image, **kwargs)
         self.port_to_expose = port_to_expose

--- a/testcontainers/arangodb.py
+++ b/testcontainers/arangodb.py
@@ -64,10 +64,11 @@ class ArangoDbContainer(DbContainer):
         ))
 
     def _configure(self):
-        self.with_env("ARANGO_NO_AUTH", "1" if self.arango_no_auth else "0")
         self.with_env("ARANGO_ROOT_PASSWORD", self.arango_root_password)
-        self.with_env("ARANGO_RANDOM_ROOT_PASSWORD",
-                      "1" if self.arango_random_root_password else "0")
+        if self.arango_no_auth:
+            self.with_env("ARANGO_NO_AUTH", "1")
+        if self.arango_random_root_password:
+            self.with_env("ARANGO_RANDOM_ROOT_PASSWORD", "1")
 
     def get_connection_url(self):
         # for now, single host over HTTP


### PR DESCRIPTION
Minor changes to let `None` default to environment variables and `True/False` to be used as is. Cf. #221.