### PR TITLE
Catch and retry DockerClient.port() 

### DIFF
--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -1,6 +1,7 @@
 from deprecation import deprecated
 from docker.models.containers import Container
 
+from testcontainers.core.waiting_utils import wait_container_is_ready
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.exceptions import ContainerStartException
 from testcontainers.core.utils import setup_logger, inside_container, is_arm
@@ -101,6 +102,7 @@ class DockerContainer(object):
             return gateway_ip
         return host
 
+    @wait_container_is_ready()
     def get_exposed_port(self, port) -> str:
         mapped_port = self.get_docker_client().port(self._container.id, port)
         if inside_container():

--- a/testcontainers/core/docker_client.py
+++ b/testcontainers/core/docker_client.py
@@ -43,7 +43,7 @@ class DockerClient(object):
     def port(self, container_id, port):
         port_mappings = self.client.api.port(container_id, port)
         if not port_mappings:
-            raise RuntimeError(f'port mapping for container {container_id} and port {port} is not '
+            raise ConnectionError(f'port mapping for container {container_id} and port {port} is not '
                                'available')
         return port_mappings[0]["HostPort"]
 

--- a/testcontainers/core/docker_client.py
+++ b/testcontainers/core/docker_client.py
@@ -43,8 +43,8 @@ class DockerClient(object):
     def port(self, container_id, port):
         port_mappings = self.client.api.port(container_id, port)
         if not port_mappings:
-            raise ConnectionError(f'port mapping for container {container_id} and port {port} is not '
-                               'available')
+            raise ConnectionError(f'port mapping for container {container_id} and port {port} is '
+                                  'not available')
         return port_mappings[0]["HostPort"]
 
     def get_container(self, container_id):


### PR DESCRIPTION
DockerClient.port() fails when called too quickly (from DockerContainer.get_exposed_port) after container start. Wrap DockerContainer.get_exposed_port in wait_container_is_ready() and change DockerClient.port to raise ConnectionError so that it can be caught and retried.