### PR TITLE
Run autopep8 to format the code

### DIFF
--- a/testcontainers/arangodb.py
+++ b/testcontainers/arangodb.py
@@ -28,6 +28,7 @@ class ArangoDbContainer(DbContainer):
             # Create a new database named "test".
             sys_db.create_database("test")
     """
+
     def __init__(self,
                  image: str = "arangodb:latest",
                  port_to_expose: int = 8529,

--- a/testcontainers/compose.py
+++ b/testcontainers/compose.py
@@ -67,6 +67,7 @@ class DockerCompose(object):
         expose:
             - "5555"
     """
+
     def __init__(
             self,
             filepath,

--- a/testcontainers/elasticsearch.py
+++ b/testcontainers/elasticsearch.py
@@ -67,6 +67,7 @@ class ElasticSearchContainer(DockerContainer):
         with ElasticSearchContainer() as es:
             connection_url = es.get_url()
     """
+
     def __init__(self, image="elasticsearch", port_to_expose=9200, **kwargs):
         super(ElasticSearchContainer, self).__init__(image, **kwargs)
         self.port_to_expose = port_to_expose

--- a/testcontainers/google/pubsub.py
+++ b/testcontainers/google/pubsub.py
@@ -33,6 +33,7 @@ class PubSubContainer(DockerContainer):
                 topic_path = publisher.topic_path(pubsub.project, "my-topic")
                 topic = publisher.create_topic(topic_path)
     """
+
     def __init__(self, image="google/cloud-sdk:latest",
                  project="test-project", port=8432, **kwargs):
         super(PubSubContainer, self).__init__(image=image, **kwargs)

--- a/testcontainers/keycloak.py
+++ b/testcontainers/keycloak.py
@@ -61,12 +61,12 @@ class KeycloakContainer(DockerContainer):
 
     def get_client(self, **kwargs):
         default_kwargs = dict(
-                server_url="{}/auth/".format(self.get_url()),
-                username=self.KEYCLOAK_USER,
-                password=self.KEYCLOAK_PASSWORD,
-                realm_name="master",
-                verify=True,
-            )
+            server_url="{}/auth/".format(self.get_url()),
+            username=self.KEYCLOAK_USER,
+            password=self.KEYCLOAK_PASSWORD,
+            realm_name="master",
+            verify=True,
+        )
         kwargs = {
             **default_kwargs,
             **kwargs

--- a/testcontainers/mssql.py
+++ b/testcontainers/mssql.py
@@ -20,6 +20,7 @@ class SqlServerContainer(DbContainer):
     Requires `ODBC Driver 17 for SQL Server <https://docs.microsoft.com/en-us/sql/connect/odbc/
     linux-mac/installing-the-microsoft-odbc-driver-for-sql-server>`_.
     """
+
     def __init__(self, image="mcr.microsoft.com/mssql/server:2019-latest", user="SA", password=None,
                  port=1433, dbname="tempdb", dialect='mssql+pymssql', **kwargs):
         super(SqlServerContainer, self).__init__(image, **kwargs)

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -33,6 +33,7 @@ class MySqlContainer(DbContainer):
             result = e.execute("select version()")
             version, = result.fetchone()
     """
+
     def __init__(self, image="mysql:latest", **kwargs):
         super(MySqlContainer, self).__init__(image)
         self.port_to_expose = 3306

--- a/testcontainers/oracle.py
+++ b/testcontainers/oracle.py
@@ -13,6 +13,7 @@ class OracleDbContainer(DbContainer):
             e = sqlalchemy.create_engine(oracle.get_connection_url())
             result = e.execute("select 1 from dual")
     """
+
     def __init__(self, image="wnameless/oracle-xe-11g-r2:latest", **kwargs):
         super(OracleDbContainer, self).__init__(image=image, **kwargs)
         self.container_port = 1521

--- a/testcontainers/selenium.py
+++ b/testcontainers/selenium.py
@@ -49,6 +49,7 @@ class BrowserWebDriverContainer(DockerContainer):
 
     You can easily change browser by passing :code:`DesiredCapabilities.FIREFOX` instead.
     """
+
     def __init__(self, capabilities, image=None, **kwargs):
         self.capabilities = capabilities
         self.image = image or get_image_name(capabilities)

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -10,5 +10,5 @@ def test_docker_run_nginx():
         url = "http://{}:{}/".format(nginx.get_container_host_ip(),
                                      nginx.get_exposed_port(port))
         r = requests.get(url)
-        assert(r.status_code == 200)
-        assert('Welcome to nginx!' in r.text)
+        assert (r.status_code == 200)
+        assert ('Welcome to nginx!' in r.text)


### PR DESCRIPTION
These are style fixes from autopep8.
Since I didn't see black configured, I used a less opinionated tool.
Suggestions to change our code to be formatted using black are welcome though.