### PR TITLE
Make kafka testcontainer compatible with confluentinc/cp-kafka:7.1.3

### DIFF
--- a/testcontainers/kafka.py
+++ b/testcontainers/kafka.py
@@ -39,7 +39,7 @@ class KafkaContainer(DockerContainer):
     def _connect(self):
         bootstrap_server = self.get_bootstrap_server()
         consumer = KafkaConsumer(group_id='test', bootstrap_servers=[bootstrap_server])
-        if not consumer.topics():
+        if not consumer.bootstrap_connected():
             raise KafkaError("Unable to connect with kafka container!")
 
     def tc_start(self):

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -13,6 +13,11 @@ def test_kafka_producer_consumer_custom_port():
         produce_and_consume_kafka_message(container)
 
 
+def test_kafka_confluent_7_1_3():
+    with KafkaContainer(image='confluentinc/cp-kafka:7.1.3') as container:
+        produce_and_consume_kafka_message(container)
+
+
 def produce_and_consume_kafka_message(container):
     topic = 'test-topic'
     bootstrap_server = container.get_bootstrap_server()


### PR DESCRIPTION
Default version is already tested with the 2 other tests of the test suite, so I just added a test starting confluentinc/cp-kafka:7.1.3 with a message roundtrip.