### PR TITLE
Configurable MongoDB exposed port

### DIFF
--- a/testcontainers/mongodb.py
+++ b/testcontainers/mongodb.py
@@ -50,10 +50,13 @@ class MongoDbContainer(DbContainer):
     MONGO_INITDB_ROOT_PASSWORD = os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")
     MONGO_DB = os.environ.get("MONGO_DB", "test")
 
-    def __init__(self, image="mongo:latest", **kwargs):
+    def __init__(self,
+                 image: str = "mongo:latest",
+                 port_to_expose: int = 27017,
+                 **kwargs):
         super(MongoDbContainer, self).__init__(image=image, **kwargs)
         self.command = "mongo"
-        self.port_to_expose = 27017
+        self.port_to_expose = port_to_expose
         self.with_exposed_ports(self.port_to_expose)
 
     def _configure(self):


### PR DESCRIPTION
Added port_to_expose argument on __init__ to configure MongoDB with different exposed ports