### PR TITLE
Pass `**kwargs` from MySqlContainer constructor to DbContainer constructor

### DIFF
--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -34,15 +34,20 @@ class MySqlContainer(DbContainer):
             version, = result.fetchone()
     """
 
-    def __init__(self, image="mysql:latest", **kwargs):
+    def __init__(self,
+                 image="mysql:latest",
+                 MYSQL_USER=None,
+                 MYSQL_ROOT_PASSWORD=None,
+                 MYSQL_PASSWORD=None,
+                 MYSQL_DATABASE=None,
+                 **kwargs):
         super(MySqlContainer, self).__init__(image, **kwargs)
         self.port_to_expose = 3306
         self.with_exposed_ports(self.port_to_expose)
-        self.MYSQL_USER = kwargs.get('MYSQL_USER', environ.get('MYSQL_USER', 'test'))
-        self.MYSQL_ROOT_PASSWORD = kwargs.get('MYSQL_ROOT_PASSWORD',
-                                              environ.get('MYSQL_ROOT_PASSWORD', 'test'))
-        self.MYSQL_PASSWORD = kwargs.get('MYSQL_PASSWORD', environ.get('MYSQL_PASSWORD', 'test'))
-        self.MYSQL_DATABASE = kwargs.get('MYSQL_DATABASE', environ.get('MYSQL_DATABASE', 'test'))
+        self.MYSQL_USER = MYSQL_USER or environ.get('MYSQL_USER', 'test')
+        self.MYSQL_ROOT_PASSWORD = MYSQL_ROOT_PASSWORD or environ.get('MYSQL_ROOT_PASSWORD', 'test')
+        self.MYSQL_PASSWORD = MYSQL_PASSWORD or environ.get('MYSQL_PASSWORD', 'test')
+        self.MYSQL_DATABASE = MYSQL_DATABASE or environ.get('MYSQL_DATABASE', 'test')
 
         if self.MYSQL_USER == 'root':
             self.MYSQL_ROOT_PASSWORD = self.MYSQL_PASSWORD

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -35,7 +35,7 @@ class MySqlContainer(DbContainer):
     """
 
     def __init__(self, image="mysql:latest", **kwargs):
-        super(MySqlContainer, self).__init__(image)
+        super(MySqlContainer, self).__init__(image, **kwargs)
         self.port_to_expose = 3306
         self.with_exposed_ports(self.port_to_expose)
         self.MYSQL_USER = kwargs.get('MYSQL_USER', environ.get('MYSQL_USER', 'test'))


### PR DESCRIPTION
Currently `MySqlContainer` does not pass `kwargs` to its base class, so we cannot customize docker client's timeout. This PR enables the users of `MySqlContainer` to set docker client's configurations via `docker_client_kw`.

Context:
We encountered read timeout errors during creation of mysql containers in our CI:
```
urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='localhost', port=2375): Read timed out. (read timeout=60)
```
We are still not sure what's the cause, but our current guess is that it's simply due to slow network.