### PR TITLE
raise an exception when docker compose fails to start

### DIFF
--- a/compose/testcontainers/compose/__init__.py
+++ b/compose/testcontainers/compose/__init__.py
@@ -10,7 +10,7 @@ import subprocess
 from typing import Iterable, List, Optional, Tuple, Union
 
 from testcontainers.core.waiting_utils import wait_container_is_ready
-from testcontainers.core.exceptions import NoSuchPortExposed
+from testcontainers.core.exceptions import ContainerStartException, NoSuchPortExposed
 
 
 class DockerCompose:
@@ -110,7 +110,10 @@ class DockerCompose:
         if self.build:
             up_cmd.append('--build')
 
-        self._call_command(cmd=up_cmd)
+        return_code = self._call_command(cmd=up_cmd)
+
+        if return_code:
+            raise ContainerStartException(f"Docker compose failed with return code {return_code}")
 
     def stop(self) -> None:
         """
@@ -194,7 +197,9 @@ class DockerCompose:
     def _call_command(self, cmd: Union[str, List[str]], filepath: Optional[str] = None) -> None:
         if filepath is None:
             filepath = self.filepath
-        subprocess.call(cmd, cwd=filepath)
+
+        return subprocess.call(cmd, cwd=filepath)
+
 
     @wait_container_is_ready(requests.exceptions.ConnectionError)
     def wait_for(self, url: str) -> 'DockerCompose':

--- a/compose/tests/test_docker_compose.py
+++ b/compose/tests/test_docker_compose.py
@@ -15,7 +15,7 @@ ROOT = os.path.dirname(__file__)
 def test_can_throw_exception_if_docker_command_fails():
     with pytest.raises(ContainerStartException):
         with DockerCompose(ROOT, compose_file_name='does-not-exist.yml'):
-            pass
+            ...
 
 
 def test_can_spawn_service_via_compose():

--- a/compose/tests/test_docker_compose.py
+++ b/compose/tests/test_docker_compose.py
@@ -5,11 +5,17 @@ import pytest
 
 from testcontainers.compose import DockerCompose
 from testcontainers.core.docker_client import DockerClient
-from testcontainers.core.exceptions import NoSuchPortExposed
+from testcontainers.core.exceptions import ContainerStartException, NoSuchPortExposed
 from testcontainers.core.waiting_utils import wait_for_logs
 
 
 ROOT = os.path.dirname(__file__)
+
+
+def test_can_throw_exception_if_docker_command_fails():
+    with pytest.raises(ContainerStartException):
+        with DockerCompose(ROOT, compose_file_name='does-not-exist.yml'):
+            pass
 
 
 def test_can_spawn_service_via_compose():


### PR DESCRIPTION
## What happened
If my docker-compose.yml has errors and I'm testing it using testcontainers, no error is reported

## What should happen
A `ContainerStartException` should be raised if docker-compose fails to start.

## Fix
Get the return code, raise exception if nonzero. See test and small change
