### PR TITLE
Workaround for docker-in-docker

### DIFF
--- a/testcontainers/core/container.py
+++ b/testcontainers/core/container.py
@@ -1,3 +1,4 @@
+import os
 from deprecation import deprecated
 from docker.models.containers import Container
 
@@ -89,7 +90,7 @@ class DockerContainer(object):
             return "localhost"
 
         # check testcontainers itself runs inside docker container
-        if inside_container():
+        if inside_container() and not os.getenv("DOCKER_HOST"):
             # If newly spawned container's gateway IP address from the docker
             # "bridge" network is equal to detected host address, we should use
             # container IP address, otherwise fall back to detected host

--- a/tests/test_core/test_docker_in_docker.py
+++ b/tests/test_core/test_docker_in_docker.py
@@ -4,7 +4,8 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 
 def test_wait_for_logs_docker_in_docker():
-    # real dind isn't possible (AFAIK) in CI, forwarding the socket to a container port is at least somewhat the same
+    # real dind isn't possible (AFAIK) in CI
+    # forwarding the socket to a container port is at least somewhat the same
     client = DockerClient()
     not_really_dind = client.run(
         image="alpine/socat",
@@ -15,7 +16,8 @@ def test_wait_for_logs_docker_in_docker():
 
     not_really_dind.start()
 
-    # get ip address for DOCKER_HOST, avoiding DockerContainer class here to prevent code changes affecting the test
+    # get ip address for DOCKER_HOST
+    # avoiding DockerContainer class here to prevent code changes affecting the test
     specs = client.get_container(not_really_dind.id)
     docker_host_ip = specs['NetworkSettings']['Networks']['bridge']['IPAddress']
     docker_host = f"tcp://{docker_host_ip}:2375"

--- a/tests/test_core/test_docker_in_docker.py
+++ b/tests/test_core/test_docker_in_docker.py
@@ -1,0 +1,39 @@
+import pytest
+import pprint
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.docker_client import DockerClient
+from testcontainers.core.waiting_utils import wait_for_logs, wait_container_is_ready
+
+
+def test_wait_for_logs_docker_in_docker():
+    # real dind isn't possible in CI, forwarding the socket to a container port is at least somewhat the same
+    client = DockerClient()
+    dind = client.run(
+        image="alpine/socat",
+        command="tcp-listen:2375,fork,reuseaddr unix-connect:/var/run/docker.sock",
+        volumes={'/var/run/docker.sock': {'bind': '/var/run/docker.sock'}},
+        detach=True,
+    )
+
+    dind.start()
+
+    specs = client.get_container(dind.id)
+    docker_host_ip = specs['NetworkSettings']['Networks']['bridge']['IPAddress']
+    docker_host = f"tcp://{docker_host_ip}:2375"
+
+    with DockerContainer(
+            image="hello-world",
+            docker_client_kw={
+                "environment": {
+                    "DOCKER_HOST": docker_host,
+                    "DOCKER_TLS_CERTDIR": ""
+                }
+            }) as container:
+        assert container.get_container_host_ip() == docker_host_ip
+        wait_for_logs(container, "Hello from Docker!")
+        stdout, stderr = container.get_logs()
+        assert stdout, 'There should be something on stdout'
+
+    dind.stop()
+    dind.remove()

--- a/tests/test_core/test_docker_in_docker.py
+++ b/tests/test_core/test_docker_in_docker.py
@@ -1,24 +1,22 @@
-import pytest
-import pprint
-
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
-from testcontainers.core.waiting_utils import wait_for_logs, wait_container_is_ready
+from testcontainers.core.waiting_utils import wait_for_logs
 
 
 def test_wait_for_logs_docker_in_docker():
-    # real dind isn't possible in CI, forwarding the socket to a container port is at least somewhat the same
+    # real dind isn't possible (AFAIK) in CI, forwarding the socket to a container port is at least somewhat the same
     client = DockerClient()
-    dind = client.run(
+    not_really_dind = client.run(
         image="alpine/socat",
         command="tcp-listen:2375,fork,reuseaddr unix-connect:/var/run/docker.sock",
         volumes={'/var/run/docker.sock': {'bind': '/var/run/docker.sock'}},
         detach=True,
     )
 
-    dind.start()
+    not_really_dind.start()
 
-    specs = client.get_container(dind.id)
+    # get ip address for DOCKER_HOST, avoiding DockerContainer class here to prevent code changes affecting the test
+    specs = client.get_container(not_really_dind.id)
     docker_host_ip = specs['NetworkSettings']['Networks']['bridge']['IPAddress']
     docker_host = f"tcp://{docker_host_ip}:2375"
 
@@ -27,7 +25,8 @@ def test_wait_for_logs_docker_in_docker():
             docker_client_kw={
                 "environment": {
                     "DOCKER_HOST": docker_host,
-                    "DOCKER_TLS_CERTDIR": ""
+                    "DOCKER_CERT_PATH": "",
+                    "DOCKER_TLS_VERIFY": ""
                 }
             }) as container:
         assert container.get_container_host_ip() == docker_host_ip
@@ -35,5 +34,5 @@ def test_wait_for_logs_docker_in_docker():
         stdout, stderr = container.get_logs()
         assert stdout, 'There should be something on stdout'
 
-    dind.stop()
-    dind.remove()
+    not_really_dind.stop()
+    not_really_dind.remove()


### PR DESCRIPTION
## Previous behaviour

In situations where the `DOCKER_HOST` env variable is set, `DockerContainer.get_container_host_ip()` returned either the gateway ip or the bridge ip instead of the actual container host ip. This caused connection issues in a docker-in-docker context, see #217. 

## Changed behaviour

The `DockerContainer.get_container_host_ip()` function now uses the container ip whether the `DOCKER_HOST` variable is set in the environment. This should fix docker-in-docker situations while leaving other scenarios in a working state. Additionally, a test has been added that attempts to simulate a docker-in-docker situation. 

## Notes

This PR is not intended to be anything more than a workaround for the current docker-in-docker issue (#217). I've intentionally kept the size and scope of the PR small to avoid making this a PR to fix all networking-related issues. It's by no means perfect, and any feedback and input on both the workaround and the test case is appreciated.