### PR TITLE
adding support for dragonfly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - nginx.py
           - rabbitmq.py
           - redis.py
+          - dragonfly.py
           - selenium.py
           - webdriver.py
           - keycloak.py

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Currently available features:
 * RabbitMQ
 * Keycloak
 * Azurite container
+* `Dragonfly DB container  <https://dragonflydb.io/>`_
 
 Installation
 ------------

--- a/testcontainers/dragonfly.py
+++ b/testcontainers/dragonfly.py
@@ -1,0 +1,58 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import redis
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+
+class DragonflyContainer(DockerContainer):
+    def __init__(self, image="docker.dragonflydb.io/dragonflydb/dragonfly:latest",
+                 port_to_expose=6379, password=None, **kwargs):
+        super(DragonflyContainer, self).__init__(image, **kwargs)
+        self.port_to_expose = port_to_expose
+        self.password = password
+        self.with_exposed_ports(self.port_to_expose)
+        if self.password:
+            self.with_command(f"dragonfly --requirepass {self.password}")
+
+    @wait_container_is_ready(redis.exceptions.ConnectionError)
+    def _connect(self):
+        client = self.get_client()
+        if not client.ping():
+            raise redis.exceptions.ConnectionError("Could not connect to Dragonfly")
+
+    def get_client(self, **kwargs):
+        """get dragonfly client
+
+        Parameters
+        ----------
+        kwargs: dict
+            Keyword arguments passed to `redis.Redis`.
+
+        Returns
+        -------
+        client: redis.Redis
+            Redis client to connect to the container.
+        """
+        return redis.Redis(
+            host=self.get_container_host_ip(),
+            port=self.get_exposed_port(self.port_to_expose),
+            password=self.password,
+            **kwargs,
+        )
+
+    def start(self):
+        super().start()
+        self._connect()
+        return self

--- a/tests/test_dragonfly.py
+++ b/tests/test_dragonfly.py
@@ -1,0 +1,52 @@
+import time
+
+from testcontainers.dragonfly import DragonflyContainer
+
+'''
+Ensure that Dragonfly is working by publishing messages
+And reading them from the subscriber side
+'''
+
+
+def test_docker_run_dragonfly():
+    config = DragonflyContainer()
+    with config as dragonfly:
+        client = dragonfly.get_client()
+        p = client.pubsub()
+        # Make sure that we are ready to get the messages
+        time.sleep(0.01)
+        # Make sure that the subscriber started
+        p.subscribe('test')
+        time.sleep(0.01)
+        client.publish('test', 'new_msg')
+        msg = wait_for_message(pubsub=p, timeout=10)
+        assert msg is not None
+        assert 'data' in msg
+        assert b'new_msg', msg['data']
+
+
+'''
+Connect to Dragonfly with password and set value, then ensure that the value
+was successfully read
+'''
+
+
+def test_docker_run_dragonfly_with_password():
+    config = DragonflyContainer(password="mypass")
+    with config as dragonfly:
+        client = dragonfly.get_client(decode_responses=True)
+        client.set("hello", "world")
+        assert client.get("hello") == "world"
+
+
+def wait_for_message(pubsub, timeout=1, ignore_subscribe_messages=True):
+    now = time.time()
+    timeout = now + timeout
+    while now < timeout:
+        message = pubsub.get_message(
+            ignore_subscribe_messages=ignore_subscribe_messages)
+        if message is not None:
+            return message
+        time.sleep(0.04)
+        now = time.time()
+    return None


### PR DESCRIPTION
This would add support to test [dragonfly](https://dragonflydb.io/) using test-containers-python
This include:
- new entry in the test containers list.
- update the readme file.
- update github workflow.
Note that since dragonfly work out of the box with the same clients as Redis, there is no requirement to change the installations or dependencies here.
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>