### PR TITLE
Removed Python 3.6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ When trying to launch a testcontainer from within a Docker container two things 
 Setting up a development environment
 ------------------------------------
 
-We recommend you use a `virtual environment <https://virtualenv.pypa.io/en/stable/>`_ for development. Note that a python version :code:`>=3.6` is required. After setting up your virtual environment, you can install all dependencies and test the installation by running the following snippet.
+We recommend you use a `virtual environment <https://virtualenv.pypa.io/en/stable/>`_ for development. Note that a python version :code:`>=3.7` is required. After setting up your virtual environment, you can install all dependencies and test the installation by running the following snippet.
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setuptools.setup(
         'Intended Audience :: Information Technology',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
@@ -72,5 +71,5 @@ setuptools.setup(
     },
     long_description_content_type="text/x-rst",
     long_description=long_description,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
The requirements for Python 3.6 were already deleted in [this commit](https://github.com/testcontainers/testcontainers-python/commit/4786acc4dbaacc4aa27fd5c71e30ffea8443e4b3) but some small changes are needed to remove the complete Python 3.6 support.

#237 