### PR TITLE
Add new postgresql env vars (#1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           - mongodb.py
           - neo4j.py
           - nginx.py
+          - postgresql.py
           - rabbitmq.py
           - redis.py
           - selenium.py

--- a/release-process.rst
+++ b/release-process.rst
@@ -10,7 +10,7 @@ Steps::
     tox -esphinx-docs
 
 
-Decleare package version
+Declare package version
 ------------------------
 
 In setup.py bump version to the next::
@@ -51,7 +51,7 @@ Steps::
     python setup.py bdist_wheel
 
 
-Check install capability for the whell
+Check install capability for the wheel
 --------------------------------------
 
 Steps::

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,39 @@
+import pytest
+import sqlalchemy
+# import time
+
+from testcontainers.postgres import PostgresContainer
+
+# >= v14 use scram-sha-256 by default, so test changing to MD5
+@pytest.mark.parametrize('version', ['14.5', '15.1'])
+def test_docker_run_postgresql_md5(version):
+    _docker_run_postgresql_test(version, "md5")
+
+
+# >= v10 to <v14 use md5 by default, so test changing to scram-sha-256.
+@pytest.mark.parametrize('version', ['12.8', '13.5'])
+def test_docker_run_postgresql_scram(version):
+    _docker_run_postgresql_test(version, "scram-sha-256")
+
+
+def _docker_run_postgresql_test(version, method):
+    test_user = 'bob' + method[:3]
+    with PostgresContainer(
+        image=f'postgres:{version}',
+        user=test_user,
+        password='hi bob',
+        initdb_args=f'--auth-host={method}',
+        host_auth_method=f'{method}'
+    ).with_bind_ports(5432, 45432) as postgres:
+        engine = sqlalchemy.create_engine(postgres.get_connection_url())
+        with engine.connect() as conn:
+            test_query = "SELECT rolname, rolpassword FROM pg_authid "\
+                         f" WHERE rolname = '{test_user}';"
+            result = conn.execute(test_query)
+            name, password = result.fetchone()
+
+            assert name == test_user
+
+            # password_method = str(password[:len(method)])
+            # password_method = password_method.lower()
+            assert method == str(password[:len(method)]).lower()


### PR DESCRIPTION
* Add support for additional PostgreSQL Container env variables.

Added interface for environment variables that the PostgreSQL container now supports:

* POSTGRES_INITDB_ARGS
* POSTGRES_INITDB_WALDIR
* POSTGRES_HOST_AUTH_METHOD
* PGDATA

As a bonus, added tests for POSTGRES_INITDB_ARGS and POSTGRES_HOST_AUTH_METHOD.

Issue #278 