### PR TITLE
Fix typo in environment variable and add warning about usage

### DIFF
--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -1,4 +1,10 @@
 from os import environ
+from warnings import warn
 
 MAX_TRIES = int(environ.get("TC_MAX_TRIES", 120))
-SLEEP_TIME = int(environ.get("TC_POOLING_INTERVAL", 1))
+
+if "TC_POOLING_INTERVAL" in environ:
+    warn("The TC_POOLING_INTERVAL environment variable is deprecated. Use TC_POLLING_INTERVAL instead.", DeprecationWarning)
+    POLLING_INTERVAL = int(environ.get("TC_POOLING_INTERVAL", 1))
+else:
+    POLLING_INTERVAL = int(environ.get("TC_POLLING_INTERVAL", 1))

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -61,7 +61,7 @@ def wait_container_is_ready(*transient_exceptions) -> Callable:
             except transient_exceptions as e:
                 logger.debug(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' "
                              f"failed: {traceback.format_exc()}")
-                time.sleep(config.SLEEP_TIME)
+                time.sleep(config.POLLING_INTERVAL)
                 exception = e
         raise TimeoutError(
             f'Wait time ({config.MAX_TRIES * config.SLEEP_TIME}s) exceeded for {wrapped.__name__}'

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -55,6 +55,10 @@ def wait_container_is_ready(*transient_exceptions) -> Callable:
             logger.info("Waiting for %s to be ready ...", instance)
 
         exception = None
+<<<<<<< HEAD:core/testcontainers/core/waiting_utils.py
+=======
+        logger.info("Waiting for %s to be ready...", instance.image)
+>>>>>>> 34c2f83 (Impove waiting logs a bit):testcontainers/core/waiting_utils.py
         for attempt_no in range(config.MAX_TRIES):
             try:
                 return wrapped(*args, **kwargs)
@@ -63,8 +67,13 @@ def wait_container_is_ready(*transient_exceptions) -> Callable:
                              f"failed: {traceback.format_exc()}")
                 time.sleep(config.POLLING_INTERVAL)
                 exception = e
+<<<<<<< HEAD:core/testcontainers/core/waiting_utils.py
         raise TimeoutError(
             f'Wait time ({config.MAX_TRIES * config.SLEEP_TIME}s) exceeded for {wrapped.__name__}'
+=======
+        raise TimeoutException(
+            f'Wait time ({config.MAX_TRIES * config.POLLING_INTERVAL}s) exceeded for {instance.image}'
+>>>>>>> 34c2f83 (Impove waiting logs a bit):testcontainers/core/waiting_utils.py
             f'(args: {args}, kwargs {kwargs}). Exception: {exception}'
         )
 


### PR DESCRIPTION
There's an obvious typo in the environment variable. This PR updates the name to reflect the behavior and adds a warning about using the old one.