### PR TITLE
make dev version PEP 440 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ try:
     with open('VERSION') as fp:
         version = fp.read().strip()
 except FileNotFoundError:
-    version = 'dev'
+    version = '0.dev0'
 
 setuptools.setup(
     name='testcontainers',


### PR DESCRIPTION
Some package managers (e.g. poetry) may enforce PEP 440 even when installing development-only version. This change supports such a use case.