### PR TITLE
Remove class-level variables from containers.

### DIFF
--- a/arangodb/testcontainers/arangodb/__init__.py
+++ b/arangodb/testcontainers/arangodb/__init__.py
@@ -36,15 +36,16 @@ class ArangoDbContainer(DbContainer):
 
     def __init__(self,
                  image: str = "arangodb:latest",
-                 port_to_expose: int = 8529,
+                 port: int = 8529,
                  arango_root_password: str = "passwd",
                  arango_no_auth: typing.Optional[bool] = None,
                  arango_random_root_password: typing.Optional[bool] = None,
+                 port_to_expose: None = None,
                  **kwargs) -> None:
         """
         Args:
             image: Actual docker image/tag to pull.
-            port_to_expose: Port the container needs to expose.
+            port: Port the container needs to expose.
             arango_root_password: Start ArangoDB with the given password for root. Defaults to the
                 environment variable `ARANGO_ROOT_PASSWORD` if `None`.
             arango_no_auth: Disable authentication completely. Defaults to the environment variable
@@ -53,9 +54,11 @@ class ArangoDbContainer(DbContainer):
                 the environment variable `ARANGO_NO_AUTH` if `None` or `False` if the environment
                 variable is not available.
         """
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super().__init__(image=image, **kwargs)
-        self.port_to_expose = port_to_expose
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
 
         # See https://www.arangodb.com/docs/stable/deployment-single-instance-manual-start.html for
         # details. We convert to int then to bool because Arango uses the string literal "1" to
@@ -77,7 +80,7 @@ class ArangoDbContainer(DbContainer):
             self.with_env("ARANGO_RANDOM_ROOT_PASSWORD", "1")
 
     def get_connection_url(self) -> str:
-        port = self.get_exposed_port(self.port_to_expose)
+        port = self.get_exposed_port(self.port)
         return f"http://{self.get_container_host_ip()}:{port}"
 
     def _connect(self) -> None:

--- a/arangodb/testcontainers/arangodb/__init__.py
+++ b/arangodb/testcontainers/arangodb/__init__.py
@@ -4,6 +4,7 @@ ArangoDB container support.
 from os import environ
 from testcontainers.core.config import TIMEOUT
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_for_logs
 import typing
 
@@ -40,7 +41,6 @@ class ArangoDbContainer(DbContainer):
                  arango_root_password: str = "passwd",
                  arango_no_auth: typing.Optional[bool] = None,
                  arango_random_root_password: typing.Optional[bool] = None,
-                 port_to_expose: None = None,
                  **kwargs) -> None:
         """
         Args:
@@ -54,8 +54,7 @@ class ArangoDbContainer(DbContainer):
                 the environment variable `ARANGO_NO_AUTH` if `None` or `False` if the environment
                 variable is not available.
         """
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super().__init__(image=image, **kwargs)
         self.port = port
         self.with_exposed_ports(self.port)

--- a/arangodb/testcontainers/arangodb/__init__.py
+++ b/arangodb/testcontainers/arangodb/__init__.py
@@ -2,7 +2,7 @@
 ArangoDB container support.
 """
 from os import environ
-from testcontainers.core.config import MAX_TRIES
+from testcontainers.core.config import TIMEOUT
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 import typing
@@ -81,4 +81,4 @@ class ArangoDbContainer(DbContainer):
         return f"http://{self.get_container_host_ip()}:{port}"
 
     def _connect(self) -> None:
-        wait_for_logs(self, predicate="is ready for business", timeout=MAX_TRIES)
+        wait_for_logs(self, predicate="is ready for business", timeout=TIMEOUT)

--- a/arangodb/tests/test_arangodb.py
+++ b/arangodb/tests/test_arangodb.py
@@ -9,7 +9,7 @@ from testcontainers.arangodb import ArangoDbContainer
 ARANGODB_IMAGE_NAME = 'arangodb'
 
 
-def arango_test_ops(arango_client, expeced_version, username='root', db_pass=''):
+def arango_test_ops(arango_client, expeced_version, username='root', password=''):
     """
     Basic ArangoDB operations to test DB really up and running.
     """
@@ -17,14 +17,14 @@ def arango_test_ops(arango_client, expeced_version, username='root', db_pass='')
 
     # Taken from https://github.com/ArangoDB-Community/python-arango/blob/main/README.md
     # Connect to "_system" database as root user.
-    sys_db = arango_client.db("_system", username=username, password=db_pass)
+    sys_db = arango_client.db("_system", username=username, password=password)
     assert sys_db.version() == expeced_version
 
     # Create a new database named "test".
     sys_db.create_database("test")
 
     # Connect to "test" database as root user.
-    database = arango_client.db("test", username=username, password=db_pass)
+    database = arango_client.db("test", username=username, password=password)
 
     # Create a new collection named "students".
     students = database.create_collection("students")
@@ -50,7 +50,7 @@ def test_docker_run_arango():
     """
     image_version = '3.9.1'
     image = f'{ARANGODB_IMAGE_NAME}:{image_version}'
-    arango_db_root_password = 'passwd'
+    arango_root_password = 'passwd'
 
     with ArangoDbContainer(image) as arango:
         client = ArangoClient(hosts=arango.get_connection_url())
@@ -63,7 +63,7 @@ def test_docker_run_arango():
         arango_test_ops(
             arango_client=client,
             expeced_version=image_version,
-            db_pass=arango_db_root_password)
+            password=arango_root_password)
 
 
 def test_docker_run_arango_without_auth():
@@ -79,7 +79,7 @@ def test_docker_run_arango_without_auth():
         arango_test_ops(
             arango_client=client,
             expeced_version=image_version,
-            db_pass='')
+            password='')
 
 
 def test_docker_run_arango_older_version():
@@ -100,7 +100,7 @@ def test_docker_run_arango_older_version():
         arango_test_ops(
             arango_client=client,
             expeced_version=image_version,
-            db_pass='')
+            password='')
 
 
 def test_docker_run_arango_random_root_password():
@@ -109,12 +109,12 @@ def test_docker_run_arango_random_root_password():
     """
     image_version = '3.9.1'
     image = f'{ARANGODB_IMAGE_NAME}:{image_version}'
-    arango_db_root_password = 'passwd'
+    arango_root_password = 'passwd'
 
     with ArangoDbContainer(image, arango_random_root_password=True) as arango:
         client = ArangoClient(hosts=arango.get_connection_url())
 
         # Test invalid auth (we don't know the password in random mode)
         with pytest.raises(ServerVersionError):
-            sys_db = client.db("_system", username='root', password=arango_db_root_password)
+            sys_db = client.db("_system", username='root', password=arango_root_password)
             assert sys_db.version() == image_version

--- a/arangodb/tests/test_arangodb.py
+++ b/arangodb/tests/test_arangodb.py
@@ -9,7 +9,7 @@ from testcontainers.arangodb import ArangoDbContainer
 ARANGODB_IMAGE_NAME = 'arangodb'
 
 
-def arango_test_ops(arango_client, expeced_version, db_user='root', db_pass=''):
+def arango_test_ops(arango_client, expeced_version, username='root', db_pass=''):
     """
     Basic ArangoDB operations to test DB really up and running.
     """
@@ -17,14 +17,14 @@ def arango_test_ops(arango_client, expeced_version, db_user='root', db_pass=''):
 
     # Taken from https://github.com/ArangoDB-Community/python-arango/blob/main/README.md
     # Connect to "_system" database as root user.
-    sys_db = arango_client.db("_system", username=db_user, password=db_pass)
+    sys_db = arango_client.db("_system", username=username, password=db_pass)
     assert sys_db.version() == expeced_version
 
     # Create a new database named "test".
     sys_db.create_database("test")
 
     # Connect to "test" database as root user.
-    database = arango_client.db("test", username=db_user, password=db_pass)
+    database = arango_client.db("test", username=username, password=db_pass)
 
     # Create a new collection named "students".
     students = database.create_collection("students")

--- a/azurite/testcontainers/azurite/__init__.py
+++ b/azurite/testcontainers/azurite/__init__.py
@@ -63,7 +63,7 @@ class AzuriteContainer(DockerContainer):
         self.queue_service_port = queue_service_port
         self.table_service_port = table_service_port
 
-        self.with_exposed_ports(*blob_service_port, queue_service_port, table_service_port)
+        self.with_exposed_ports(blob_service_port, queue_service_port, table_service_port)
         self.with_env("AZURITE_ACCOUNTS", f"{self.account_name}:{self.account_key}")
 
     def get_connection_string(self) -> str:

--- a/azurite/testcontainers/azurite/__init__.py
+++ b/azurite/testcontainers/azurite/__init__.py
@@ -12,43 +12,43 @@
 #    under the License.
 import os
 import socket
-from typing import Iterable, Optional
+from typing import Optional
 
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
 class AzuriteContainer(DockerContainer):
     """
-        The example below spins up an Azurite container and
-        shows an example to create a Blob service client with the container. The method
-        :code:`get_connection_string` can be used to create a client for Blob service, Queue service
-        and Table service.
+    The example below spins up an Azurite container and
+    shows an example to create a Blob service client with the container. The method
+    :code:`get_connection_string` can be used to create a client for Blob service, Queue service
+    and Table service.
 
-        Example:
+    Example:
 
-            .. doctest::
+        .. doctest::
 
-                >>> from testcontainers.azurite import AzuriteContainer
-                >>> from azure.storage.blob import BlobServiceClient
+            >>> from testcontainers.azurite import AzuriteContainer
+            >>> from azure.storage.blob import BlobServiceClient
 
-                >>> with AzuriteContainer() as azurite_container:
-                ...   connection_string = azurite_container.get_connection_string()
-                ...   client = BlobServiceClient.from_connection_string(
-                ...        connection_string,
-                ...        api_version="2019-12-12"
-                ...   )
-        """
+            >>> with AzuriteContainer() as azurite_container:
+            ...   connection_string = azurite_container.get_connection_string()
+            ...   client = BlobServiceClient.from_connection_string(
+            ...        connection_string,
+            ...        api_version="2019-12-12"
+            ...   )
+    """
     def __init__(self, image: str = "mcr.microsoft.com/azure-storage/azurite:latest", *,
-                 ports_to_expose: Optional[Iterable[int]] = None, blob_service_port: int = 10_000,
-                 queue_service_port: int = 10_001, table_service_port: int = 10_002,
-                 account_name: Optional[str] = None, account_key: Optional[str] = None, **kwargs) \
+                 blob_service_port: int = 10_000, queue_service_port: int = 10_001,
+                 table_service_port: int = 10_002, account_name: Optional[str] = None,
+                 account_key: Optional[str] = None, **kwargs) \
             -> None:
         """ Constructs an AzuriteContainer.
 
         Args:
             image: Expects an image with tag.
-            ports_to_expose: List with port numbers to expose.
             **kwargs: Keyword arguments passed to super class.
         """
         super().__init__(image=image, **kwargs)
@@ -58,13 +58,12 @@ class AzuriteContainer(DockerContainer):
             "AZURITE_ACCOUNT_KEY", "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
             "K1SZFPTOtr/KBHBeksoGMGw==")
 
+        raise_for_deprecated_parameter(kwargs, "ports_to_expose", "container.with_exposed_ports")
         self.blob_service_port = blob_service_port
         self.queue_service_port = queue_service_port
         self.table_service_port = table_service_port
-        if not ports_to_expose:
-            ports_to_expose = [blob_service_port, queue_service_port, table_service_port]
 
-        self.with_exposed_ports(*ports_to_expose)
+        self.with_exposed_ports(*blob_service_port, queue_service_port, table_service_port)
         self.with_env("AZURITE_ACCOUNTS", f"{self.account_name}:{self.account_key}")
 
     def get_connection_string(self) -> str:

--- a/azurite/testcontainers/azurite/__init__.py
+++ b/azurite/testcontainers/azurite/__init__.py
@@ -39,18 +39,11 @@ class AzuriteContainer(DockerContainer):
                 ...        api_version="2019-12-12"
                 ...   )
         """
-
-    _AZURITE_ACCOUNT_NAME = os.environ.get("AZURITE_ACCOUNT_NAME", "devstoreaccount1")
-    _AZURITE_ACCOUNT_KEY = os.environ.get("AZURITE_ACCOUNT_KEY", "Eby8vdM02xNOcqFlqUwJPLlmEtlCDX"
-                                          "J1OUzFT50uSRZ6IFsuFq2UVErCz4I6"
-                                          "tq/K1SZFPTOtr/KBHBeksoGMGw==")
-
-    _BLOB_SERVICE_PORT = 10_000
-    _QUEUE_SERVICE_PORT = 10_001
-    _TABLE_SERVICE_PORT = 10_002
-
-    def __init__(self, image: str = "mcr.microsoft.com/azure-storage/azurite:latest",
-                 ports_to_expose: Optional[Iterable[int]] = None, **kwargs) -> None:
+    def __init__(self, image: str = "mcr.microsoft.com/azure-storage/azurite:latest", *,
+                 ports_to_expose: Optional[Iterable[int]] = None, blob_service_port: int = 10_000,
+                 queue_service_port: int = 10_001, table_service_port: int = 10_002,
+                 account_name: Optional[str] = None, account_key: Optional[str] = None, **kwargs) \
+            -> None:
         """ Constructs an AzuriteContainer.
 
         Args:
@@ -59,41 +52,41 @@ class AzuriteContainer(DockerContainer):
             **kwargs: Keyword arguments passed to super class.
         """
         super().__init__(image=image, **kwargs)
+        self.account_name = account_name or os.environ.get(
+            "AZURITE_ACCOUNT_NAME", "devstoreaccount1")
+        self.account_key = account_key or os.environ.get(
+            "AZURITE_ACCOUNT_KEY", "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+            "K1SZFPTOtr/KBHBeksoGMGw==")
 
-        if ports_to_expose is None:
-            ports_to_expose = [
-                self._BLOB_SERVICE_PORT,
-                self._QUEUE_SERVICE_PORT,
-                self._TABLE_SERVICE_PORT
-            ]
-
-        if len(ports_to_expose) == 0:
-            raise ValueError("Expected a list with port numbers to expose")
+        self.blob_service_port = blob_service_port
+        self.queue_service_port = queue_service_port
+        self.table_service_port = table_service_port
+        if not ports_to_expose:
+            ports_to_expose = [blob_service_port, queue_service_port, table_service_port]
 
         self.with_exposed_ports(*ports_to_expose)
-        self.with_env("AZURITE_ACCOUNTS",
-                      f"{self._AZURITE_ACCOUNT_NAME}:{self._AZURITE_ACCOUNT_KEY}")
+        self.with_env("AZURITE_ACCOUNTS", f"{self.account_name}:{self.account_key}")
 
     def get_connection_string(self) -> str:
         host_ip = self.get_container_host_ip()
         connection_string = f"DefaultEndpointsProtocol=http;" \
-                            f"AccountName={self._AZURITE_ACCOUNT_NAME};" \
-                            f"AccountKey={self._AZURITE_ACCOUNT_KEY};"
+                            f"AccountName={self.account_name};" \
+                            f"AccountKey={self.account_key};"
 
-        if self._BLOB_SERVICE_PORT in self.ports:
+        if self.blob_service_port in self.ports:
             connection_string += f"BlobEndpoint=http://{host_ip}:" \
-                                 f"{self.get_exposed_port(self._BLOB_SERVICE_PORT)}" \
-                                 f"/{self._AZURITE_ACCOUNT_NAME};"
+                                 f"{self.get_exposed_port(self.blob_service_port)}" \
+                                 f"/{self.account_name};"
 
-        if self._QUEUE_SERVICE_PORT in self.ports:
+        if self.queue_service_port in self.ports:
             connection_string += f"QueueEndpoint=http://{host_ip}:" \
-                                 f"{self.get_exposed_port(self._QUEUE_SERVICE_PORT)}" \
-                                 f"/{self._AZURITE_ACCOUNT_NAME};"
+                                 f"{self.get_exposed_port(self.queue_service_port)}" \
+                                 f"/{self.account_name};"
 
-        if self._TABLE_SERVICE_PORT in self.ports:
+        if self.table_service_port in self.ports:
             connection_string += f"TableEndpoint=http://{host_ip}:" \
-                                 f"{self.get_exposed_port(self._TABLE_SERVICE_PORT)}" \
-                                 f"/{self._AZURITE_ACCOUNT_NAME};"
+                                 f"{self.get_exposed_port(self.table_service_port)}" \
+                                 f"/{self.account_name};"
 
         return connection_string
 

--- a/clickhouse/testcontainers/clickhouse/__init__.py
+++ b/clickhouse/testcontainers/clickhouse/__init__.py
@@ -39,24 +39,21 @@ class ClickHouseContainer(DbContainer):
             ...     client.execute("select 'working'")
             [('working',)]
     """
-
-    CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "test")
-    CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "test")
-    CLICKHOUSE_DB = os.environ.get("CLICKHOUSE_DB", "test")
-
     def __init__(
             self,
             image: str = "clickhouse/clickhouse-server:latest",
             port: int = 9000,
-            user: Optional[str] = None,
+            username: Optional[str] = None,
             password: Optional[str] = None,
-            dbname: Optional[str] = None
+            dbname: Optional[str] = None,
+            user: None = None,
     ) -> None:
         super().__init__(image=image)
-
-        self.CLICKHOUSE_USER = user or self.CLICKHOUSE_USER
-        self.CLICKHOUSE_PASSWORD = password or self.CLICKHOUSE_PASSWORD
-        self.CLICKHOUSE_DB = dbname or self.CLICKHOUSE_DB
+        if user:
+            raise ValueError("use `username` instead")
+        self.username = username or os.environ.get("CLICKHOUSE_USER", "test")
+        self.password = password or os.environ.get("CLICKHOUSE_PASSWORD", "test")
+        self.dbname = dbname or self.os.environ.get("CLICKHOUSE_DB", "test")
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
 
@@ -66,16 +63,16 @@ class ClickHouseContainer(DbContainer):
             client.execute("SELECT version()")
 
     def _configure(self) -> None:
-        self.with_env("CLICKHOUSE_USER", self.CLICKHOUSE_USER)
-        self.with_env("CLICKHOUSE_PASSWORD", self.CLICKHOUSE_PASSWORD)
-        self.with_env("CLICKHOUSE_DB", self.CLICKHOUSE_DB)
+        self.with_env("CLICKHOUSE_USER", self.username)
+        self.with_env("CLICKHOUSE_PASSWORD", self.password)
+        self.with_env("CLICKHOUSE_DB", self.dbname)
 
     def get_connection_url(self, host: Optional[str] = None) -> str:
         return self._create_connection_url(
             dialect="clickhouse",
-            username=self.CLICKHOUSE_USER,
-            password=self.CLICKHOUSE_PASSWORD,
-            db_name=self.CLICKHOUSE_DB,
+            username=self.username,
+            password=self.password,
+            db_name=self.dbname,
             host=host,
             port=self.port_to_expose,
         )

--- a/clickhouse/testcontainers/clickhouse/__init__.py
+++ b/clickhouse/testcontainers/clickhouse/__init__.py
@@ -72,7 +72,7 @@ class ClickHouseContainer(DbContainer):
             dialect="clickhouse",
             username=self.username,
             password=self.password,
-            db_name=self.dbname,
+            dbname=self.dbname,
             host=host,
             port=self.port_to_expose,
         )

--- a/clickhouse/testcontainers/clickhouse/__init__.py
+++ b/clickhouse/testcontainers/clickhouse/__init__.py
@@ -48,8 +48,8 @@ class ClickHouseContainer(DbContainer):
         self.username = username or os.environ.get("CLICKHOUSE_USER", "test")
         self.password = password or os.environ.get("CLICKHOUSE_PASSWORD", "test")
         self.dbname = dbname or os.environ.get("CLICKHOUSE_DB", "test")
-        self.port_to_expose = port
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
 
     @wait_container_is_ready(Error, EOFError)
     def _connect(self) -> None:
@@ -68,5 +68,5 @@ class ClickHouseContainer(DbContainer):
             password=self.password,
             dbname=self.dbname,
             host=host,
-            port=self.port_to_expose,
+            port=self.port,
         )

--- a/clickhouse/testcontainers/clickhouse/__init__.py
+++ b/clickhouse/testcontainers/clickhouse/__init__.py
@@ -53,7 +53,7 @@ class ClickHouseContainer(DbContainer):
             raise ValueError("use `username` instead")
         self.username = username or os.environ.get("CLICKHOUSE_USER", "test")
         self.password = password or os.environ.get("CLICKHOUSE_PASSWORD", "test")
-        self.dbname = dbname or self.os.environ.get("CLICKHOUSE_DB", "test")
+        self.dbname = dbname or os.environ.get("CLICKHOUSE_DB", "test")
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
 

--- a/clickhouse/testcontainers/clickhouse/__init__.py
+++ b/clickhouse/testcontainers/clickhouse/__init__.py
@@ -17,6 +17,7 @@ import clickhouse_driver
 from clickhouse_driver.errors import Error
 
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
@@ -39,18 +40,11 @@ class ClickHouseContainer(DbContainer):
             ...     client.execute("select 'working'")
             [('working',)]
     """
-    def __init__(
-            self,
-            image: str = "clickhouse/clickhouse-server:latest",
-            port: int = 9000,
-            username: Optional[str] = None,
-            password: Optional[str] = None,
-            dbname: Optional[str] = None,
-            user: None = None,
-    ) -> None:
-        super().__init__(image=image)
-        if user:
-            raise ValueError("use `username` instead")
+    def __init__(self, image: str = "clickhouse/clickhouse-server:latest", port: int = 9000,
+                 username: Optional[str] = None, password: Optional[str] = None,
+                 dbname: Optional[str] = None, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "user", "username")
+        super().__init__(image=image, **kwargs)
         self.username = username or os.environ.get("CLICKHOUSE_USER", "test")
         self.password = password or os.environ.get("CLICKHOUSE_PASSWORD", "test")
         self.dbname = dbname or os.environ.get("CLICKHOUSE_DB", "test")

--- a/compose/testcontainers/compose/__init__.py
+++ b/compose/testcontainers/compose/__init__.py
@@ -36,13 +36,13 @@ class DockerCompose:
                 host = compose.get_service_host("hub", 4444)
                 port = compose.get_service_port("hub", 4444)
                 driver = webdriver.Remote(
-                    command_executor=("http://{}:{}/wd/hub".format(host,port)),
+                    command_executor=(f"http://{host}:{port}/wd/hub"),
                     desired_capabilities=CHROME,
                 )
                 driver.get("http://automation-remarks.com")
                 stdout, stderr = compose.get_logs()
                 if stderr:
-                    print("Errors\\n:{}".format(stderr))
+                    print(f"Errors\\n:{stderr}")
 
         .. code-block:: yaml
 

--- a/compose/testcontainers/compose/__init__.py
+++ b/compose/testcontainers/compose/__init__.py
@@ -1,10 +1,3 @@
-"""
-Docker Compose Support
-======================
-
-Allows to spin up services configured via :code:`docker-compose.yml`.
-"""
-
 import requests
 import subprocess
 from typing import Iterable, List, Optional, Tuple, Union

--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -2,3 +2,4 @@ from os import environ
 
 MAX_TRIES = int(environ.get("TC_MAX_TRIES", 120))
 SLEEP_TIME = int(environ.get("TC_POOLING_INTERVAL", 1))
+TIMEOUT = MAX_TRIES * SLEEP_TIME

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -61,7 +61,7 @@ class DockerClient:
         """
         port_mappings = self.client.api.port(container_id, port)
         if not port_mappings:
-            raise ConnectionError(f'port mapping for container {container_id} and port {port} is '
+            raise ConnectionError(f'Port mapping for container {container_id} and port {port} is '
                                   'not available')
         return port_mappings[0]["HostPort"]
 
@@ -71,7 +71,7 @@ class DockerClient:
         """
         containers = self.client.api.containers(filters={'id': container_id})
         if not containers:
-            raise RuntimeError(f'could not get container with id {container_id}')
+            raise RuntimeError(f'Could not get container with id {container_id}')
         return containers[0]
 
     def bridge_ip(self, container_id: str) -> str:

--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from .container import DockerContainer
 from .exceptions import ContainerStartException
+from .utils import raise_for_deprecated_parameter
 from .waiting_utils import wait_container_is_ready
 
 ADDITIONAL_TRANSIENT_ERRORS = []
@@ -39,9 +40,9 @@ class DbContainer(DockerContainer):
 
     def _create_connection_url(self, dialect: str, username: str, password: str,
                                host: Optional[str] = None, port: Optional[int] = None,
-                               dbname: Optional[str] = None, db_name: None = None) -> str:
-        if db_name:
-            raise ValueError("use `dbname` instead of `db_name`")
+                               dbname: Optional[str] = None, **kwargs) -> str:
+        if raise_for_deprecated_parameter(kwargs, "db_name", "dbname"):
+            raise ValueError(f"unexpected arguments: {','.join(kwargs)}")
         if self._container is None:
             raise ContainerStartException("container has not been started")
         host = host or self.get_container_host_ip()

--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -39,14 +39,16 @@ class DbContainer(DockerContainer):
 
     def _create_connection_url(self, dialect: str, username: str, password: str,
                                host: Optional[str] = None, port: Optional[int] = None,
-                               db_name: Optional[str] = None) -> str:
+                               dbname: Optional[str] = None, db_name: None = None) -> str:
+        if db_name:
+            raise ValueError("use `dbname` instead of `db_name`")
         if self._container is None:
             raise ContainerStartException("container has not been started")
         host = host or self.get_container_host_ip()
         port = self.get_exposed_port(port)
         url = f"{dialect}://{username}:{password}@{host}:{port}"
-        if db_name:
-            url = f"{url}/{db_name}"
+        if dbname:
+            url = f"{url}/{dbname}"
         return url
 
     def start(self) -> 'DbContainer':

--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -44,11 +44,9 @@ class DbContainer(DockerContainer):
             raise ContainerStartException("container has not been started")
         host = host or self.get_container_host_ip()
         port = self.get_exposed_port(port)
-        url = "{dialect}://{username}:{password}@{host}:{port}".format(
-            dialect=dialect, username=username, password=password, host=host, port=port
-        )
+        url = f"{dialect}://{username}:{password}@{host}:{port}"
         if db_name:
-            url += '/' + db_name
+            url = f"{url}/{db_name}"
         return url
 
     def start(self) -> 'DbContainer':

--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -42,7 +42,7 @@ class DbContainer(DockerContainer):
                                host: Optional[str] = None, port: Optional[int] = None,
                                dbname: Optional[str] = None, **kwargs) -> str:
         if raise_for_deprecated_parameter(kwargs, "db_name", "dbname"):
-            raise ValueError(f"unexpected arguments: {','.join(kwargs)}")
+            raise ValueError(f"Unexpected arguments: {','.join(kwargs)}")
         if self._container is None:
             raise ContainerStartException("container has not been started")
         host = host or self.get_container_host_ip()

--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -69,3 +69,12 @@ def default_gateway_ip() -> str:
             return ip_address.decode('utf-8').strip().strip('\n')
     except subprocess.SubprocessError:
         return None
+
+
+def raise_for_deprecated_parameter(kwargs: dict, name: str, replacement: str) -> dict:
+    """
+    Raise an error if a dictionary of keyword arguments contains a key and suggest the replacement.
+    """
+    if kwargs.pop(name, None):
+        raise ValueError(f"use `{replacement}` instead of `{name}`")
+    return kwargs

--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -76,5 +76,5 @@ def raise_for_deprecated_parameter(kwargs: dict, name: str, replacement: str) ->
     Raise an error if a dictionary of keyword arguments contains a key and suggest the replacement.
     """
     if kwargs.pop(name, None):
-        raise ValueError(f"use `{replacement}` instead of `{name}`")
+        raise ValueError(f"Use `{replacement}` instead of `{name}`")
     return kwargs

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -64,8 +64,8 @@ def wait_container_is_ready(*transient_exceptions) -> Callable:
                 time.sleep(config.SLEEP_TIME)
                 exception = e
         raise TimeoutError(
-            f'Wait time ({config.MAX_TRIES * config.SLEEP_TIME}s) exceeded for {wrapped.__name__}'
-            f'(args: {args}, kwargs {kwargs}). Exception: {exception}'
+            f'Wait time ({config.TIMEOUT}s) exceeded for {wrapped.__name__}(args: {args}, kwargs '
+            f'{kwargs}). Exception: {exception}'
         )
 
     return wrapper

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -64,7 +64,7 @@ def wait_container_is_ready(*transient_exceptions) -> Callable:
                 time.sleep(config.SLEEP_TIME)
                 exception = e
         raise TimeoutError(
-            f'Wait time ({config.TIMEOUT}s) exceeded for {wrapped.__name__}(args: {args}, kwargs '
+            f'Wait time ({config.TIMEOUT}s) exceeded for {wrapped.__name__}(args: {args}, kwargs: '
             f'{kwargs}). Exception: {exception}'
         )
 

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -102,6 +102,6 @@ def wait_for_logs(container: "DockerContainer", predicate: Union[Callable, str],
         if predicate(stdout) or predicate(stderr):
             return duration
         if timeout and duration > timeout:
-            raise TimeoutError("container did not emit logs satisfying predicate in %.3f seconds"
-                               % timeout)
+            raise TimeoutError(f"Container did not emit logs satisfying predicate in {timeout:.3f} "
+                               "seconds")
         time.sleep(interval)

--- a/core/tests/test_docker_in_docker.py
+++ b/core/tests/test_docker_in_docker.py
@@ -1,8 +1,10 @@
+import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.waiting_utils import wait_for_logs
 
 
+@pytest.mark.xfail(reason="https://github.com/docker/docker-py/issues/2717")
 def test_wait_for_logs_docker_in_docker():
     # real dind isn't possible (AFAIK) in CI
     # forwarding the socket to a container port is at least somewhat the same

--- a/core/tests/test_new_docker_api.py
+++ b/core/tests/test_new_docker_api.py
@@ -1,12 +1,6 @@
-import os
 from pathlib import Path
 
 from testcontainers.core.container import DockerContainer
-
-
-def setup_module(m):
-    os.environ["MYSQL_USER"] = "demo"
-    os.environ["MYSQL_DATABASE"] = "custom_db"
 
 
 def test_docker_custom_image():

--- a/elasticsearch/testcontainers/elasticsearch/__init__.py
+++ b/elasticsearch/testcontainers/elasticsearch/__init__.py
@@ -73,9 +73,12 @@ class ElasticSearchContainer(DockerContainer):
             '8.3.3'
     """
 
-    def __init__(self, image="elasticsearch", port_to_expose=9200, **kwargs) -> None:
+    def __init__(self, image: str = "elasticsearch", port: int = 9200, port_to_expose: None = None,
+                 **kwargs) -> None:
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(ElasticSearchContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port_to_expose
+        self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
         self.with_env('transport.host', '127.0.0.1')
         self.with_env('http.host', '0.0.0.0')

--- a/elasticsearch/testcontainers/elasticsearch/__init__.py
+++ b/elasticsearch/testcontainers/elasticsearch/__init__.py
@@ -17,6 +17,7 @@ from typing import Dict
 from urllib.error import URLError
 
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 _FALLBACK_VERSION = 8
@@ -73,10 +74,8 @@ class ElasticSearchContainer(DockerContainer):
             '8.3.3'
     """
 
-    def __init__(self, image: str = "elasticsearch", port: int = 9200, port_to_expose: None = None,
-                 **kwargs) -> None:
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+    def __init__(self, image: str = "elasticsearch", port: int = 9200, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(ElasticSearchContainer, self).__init__(image, **kwargs)
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)

--- a/elasticsearch/testcontainers/elasticsearch/__init__.py
+++ b/elasticsearch/testcontainers/elasticsearch/__init__.py
@@ -93,7 +93,7 @@ class ElasticSearchContainer(DockerContainer):
     def get_url(self) -> str:
         host = self.get_container_host_ip()
         port = self.get_exposed_port(self.port_to_expose)
-        return 'http://{}:{}'.format(host, port)
+        return f'http://{host}:{port}'
 
     def start(self) -> "ElasticSearchContainer":
         super().start()

--- a/elasticsearch/testcontainers/elasticsearch/__init__.py
+++ b/elasticsearch/testcontainers/elasticsearch/__init__.py
@@ -77,8 +77,8 @@ class ElasticSearchContainer(DockerContainer):
     def __init__(self, image: str = "elasticsearch", port: int = 9200, **kwargs) -> None:
         raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(ElasticSearchContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
         self.with_env('transport.host', '127.0.0.1')
         self.with_env('http.host', '0.0.0.0')
 
@@ -94,7 +94,7 @@ class ElasticSearchContainer(DockerContainer):
 
     def get_url(self) -> str:
         host = self.get_container_host_ip()
-        port = self.get_exposed_port(self.port_to_expose)
+        port = self.get_exposed_port(self.port)
         return f'http://{host}:{port}'
 
     def start(self) -> "ElasticSearchContainer":

--- a/google/testcontainers/google/__init__.py
+++ b/google/testcontainers/google/__init__.py
@@ -1,8 +1,1 @@
-"""
-Google Cloud Emulators
-======================
-
-Allows to spin up google cloud emulators, such as PubSub.
-"""
-
 from .pubsub import PubSubContainer  # noqa

--- a/google/testcontainers/google/pubsub.py
+++ b/google/testcontainers/google/pubsub.py
@@ -42,14 +42,12 @@ class PubSubContainer(DockerContainer):
         self.project = project
         self.port = port
         self.with_exposed_ports(self.port)
-        self.with_command("gcloud beta emulators pubsub start --project="
-                          "{project} --host-port=0.0.0.0:{port}".format(
-                              project=self.project, port=self.port,
-                          ))
+        self.with_command(
+            f"gcloud beta emulators pubsub start --project={project} --host-port=0.0.0.0:{port}"
+        )
 
     def get_pubsub_emulator_host(self) -> str:
-        return "{host}:{port}".format(host=self.get_container_host_ip(),
-                                      port=self.get_exposed_port(self.port))
+        return f"{self.get_container_host_ip()}:{self.get_exposed_port(self.port)}"
 
     def _get_channel(self, channel: Optional[grpc.Channel] = None) -> grpc.Channel:
         if channel is None:

--- a/kafka/testcontainers/kafka/__init__.py
+++ b/kafka/testcontainers/kafka/__init__.py
@@ -7,6 +7,7 @@ from kafka import KafkaConsumer
 from kafka.errors import KafkaError, UnrecognizedBrokerVersion, NoBrokersAvailable
 
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
@@ -25,10 +26,9 @@ class KafkaContainer(DockerContainer):
     """
     TC_START_SCRIPT = '/tc-start.sh'
 
-    def __init__(self, image: str = "confluentinc/cp-kafka:5.4.3", port: int = 9093,
-                 port_to_expose: None = None, **kwargs) -> None:
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+    def __init__(self, image: str = "confluentinc/cp-kafka:5.4.3", port: int = 9093, **kwargs) \
+            -> None:
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(KafkaContainer, self).__init__(image, **kwargs)
         self.port = port
         self.with_exposed_ports(self.port)

--- a/kafka/testcontainers/kafka/__init__.py
+++ b/kafka/testcontainers/kafka/__init__.py
@@ -23,10 +23,9 @@ class KafkaContainer(DockerContainer):
             >>> with KafkaContainer() as kafka:
             ...    connection = kafka.get_bootstrap_server()
     """
-    KAFKA_PORT = 9093
     TC_START_SCRIPT = '/tc-start.sh'
 
-    def __init__(self, image: str = "confluentinc/cp-kafka:5.4.3", port_to_expose: int = KAFKA_PORT,
+    def __init__(self, image: str = "confluentinc/cp-kafka:5.4.3", port_to_expose: int = 9093,
                  **kwargs) -> None:
         super(KafkaContainer, self).__init__(image, **kwargs)
         self.port_to_expose = port_to_expose

--- a/kafka/tests/test_kafka.py
+++ b/kafka/tests/test_kafka.py
@@ -8,8 +8,8 @@ def test_kafka_producer_consumer():
 
 
 def test_kafka_producer_consumer_custom_port():
-    with KafkaContainer(port_to_expose=9888) as container:
-        assert container.port_to_expose == 9888
+    with KafkaContainer(port=9888) as container:
+        assert container.port == 9888
         produce_and_consume_kafka_message(container)
 
 

--- a/keycloak/testcontainers/keycloak/__init__.py
+++ b/keycloak/testcontainers/keycloak/__init__.py
@@ -38,8 +38,8 @@ class KeycloakContainer(DockerContainer):
         super(KeycloakContainer, self).__init__(image=image)
         self.username = username or os.environ.get("KEYCLOAK_USER", "test")
         self.password = password or os.environ.get("KEYCLOAK_PASSWORD", "test")
-        self.port_to_expose = port
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
 
     def _configure(self) -> None:
         self.with_env("KEYCLOAK_USER", self.username)
@@ -47,7 +47,7 @@ class KeycloakContainer(DockerContainer):
 
     def get_url(self) -> str:
         host = self.get_container_host_ip()
-        port = self.get_exposed_port(self.port_to_expose)
+        port = self.get_exposed_port(self.port)
         return f"http://{host}:{port}"
 
     @wait_container_is_ready(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout)

--- a/keycloak/testcontainers/keycloak/__init__.py
+++ b/keycloak/testcontainers/keycloak/__init__.py
@@ -17,6 +17,7 @@ from keycloak import KeycloakAdmin
 
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
+from typing import Optional
 
 
 class KeycloakContainer(DockerContainer):
@@ -32,17 +33,17 @@ class KeycloakContainer(DockerContainer):
             >>> with KeycloakContainer() as kc:
             ...    keycloak = kc.get_client()
     """
-    KEYCLOAK_USER = os.environ.get("KEYCLOAK_USER", "test")
-    KEYCLOAK_PASSWORD = os.environ.get("KEYCLOAK_PASSWORD", "test")
-
-    def __init__(self, image="jboss/keycloak:latest") -> None:
+    def __init__(self, image="jboss/keycloak:latest", username: Optional[str] = None,
+                 password: Optional[str] = None, port: int = 8080) -> None:
         super(KeycloakContainer, self).__init__(image=image)
-        self.port_to_expose = 8080
+        self.username = username or os.environ.get("KEYCLOAK_USER", "test")
+        self.password = password or os.environ.get("KEYCLOAK_PASSWORD", "test")
+        self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
 
     def _configure(self) -> None:
-        self.with_env("KEYCLOAK_USER", self.KEYCLOAK_USER)
-        self.with_env("KEYCLOAK_PASSWORD", self.KEYCLOAK_PASSWORD)
+        self.with_env("KEYCLOAK_USER", self.username)
+        self.with_env("KEYCLOAK_PASSWORD", self.password)
 
     def get_url(self) -> str:
         host = self.get_container_host_ip()
@@ -64,8 +65,8 @@ class KeycloakContainer(DockerContainer):
     def get_client(self, **kwargs) -> KeycloakAdmin:
         default_kwargs = dict(
             server_url="{}/auth/".format(self.get_url()),
-            username=self.KEYCLOAK_USER,
-            password=self.KEYCLOAK_PASSWORD,
+            username=self.username,
+            password=self.password,
             realm_name="master",
             verify=True,
         )

--- a/keycloak/testcontainers/keycloak/__init__.py
+++ b/keycloak/testcontainers/keycloak/__init__.py
@@ -48,12 +48,12 @@ class KeycloakContainer(DockerContainer):
     def get_url(self) -> str:
         host = self.get_container_host_ip()
         port = self.get_exposed_port(self.port_to_expose)
-        return "http://{}:{}".format(host, port)
+        return f"http://{host}:{port}"
 
     @wait_container_is_ready(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout)
     def _connect(self) -> None:
         url = self.get_url()
-        response = requests.get("{}/auth".format(url), timeout=1)
+        response = requests.get(f"{url}/auth", timeout=1)
         response.raise_for_status()
 
     def start(self) -> "KeycloakContainer":
@@ -64,7 +64,7 @@ class KeycloakContainer(DockerContainer):
 
     def get_client(self, **kwargs) -> KeycloakAdmin:
         default_kwargs = dict(
-            server_url="{}/auth/".format(self.get_url()),
+            server_url=f"{self.get_url()}/auth/",
             username=self.username,
             password=self.password,
             realm_name="master",

--- a/keycloak/tests/test_keycloak.py
+++ b/keycloak/tests/test_keycloak.py
@@ -3,7 +3,7 @@ import pytest
 from testcontainers.keycloak import KeycloakContainer
 
 
-@pytest.mark.parametrize(["version"], [("16.1.1", )])
-def test_docker_run_keycloak(version):
-    with KeycloakContainer('jboss/keycloak:{}'.format(version)) as kc:
+@pytest.mark.parametrize("version", ["16.1.1"])
+def test_docker_run_keycloak(version: str):
+    with KeycloakContainer(f'jboss/keycloak:{version}') as kc:
         kc.get_client().users_count()

--- a/localstack/testcontainers/localstack/__init__.py
+++ b/localstack/testcontainers/localstack/__init__.py
@@ -62,7 +62,7 @@ class LocalStackContainer(DockerContainer):
         """
         host = self.get_container_host_ip()
         port = self.get_exposed_port(self.edge_port)
-        return 'http://{}:{}'.format(host, port)
+        return f'http://{host}:{port}'
 
     def start(self, timeout: float = 60) -> "LocalStackContainer":
         super().start()

--- a/localstack/tests/test_localstack.py
+++ b/localstack/tests/test_localstack.py
@@ -6,7 +6,7 @@ from testcontainers.localstack import LocalStackContainer
 
 def test_docker_run_localstack():
     with LocalStackContainer() as localstack:
-        resp = urllib.request.urlopen('{}/health'.format(localstack.get_url()))
+        resp = urllib.request.urlopen(f'{localstack.get_url()}/health')
         services = json.loads(resp.read().decode())['services']
 
         # Check that all services are running

--- a/minio/testcontainers/minio/__init__.py
+++ b/minio/testcontainers/minio/__init__.py
@@ -35,24 +35,26 @@ class MinioContainer(DockerContainer):
     """
 
     def __init__(self, image: str = "minio/minio:RELEASE.2022-12-02T19-19-22Z",
-                 port_to_expose: int = 9000, access_key: str = "minioadmin",
-                 secret_key: str = "minioadmin", **kwargs) -> None:
+                 port: int = 9000, access_key: str = "minioadmin",
+                 secret_key: str = "minioadmin", port_to_expose: None = None, **kwargs) -> None:
         """
         Args:
             image: Docker image to use for the MinIO container.
-            port_to_expose: Port to expose on the container.
+            port: Port to expose on the container.
             access_key: Access key for client connections.
             secret_key: Secret key for client connections.
         """
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(MinioContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port_to_expose
+        self.port = port
         self.access_key = access_key
         self.secret_key = secret_key
 
-        self.with_exposed_ports(self.port_to_expose)
+        self.with_exposed_ports(self.port)
         self.with_env("MINIO_ACCESS_KEY", self.access_key)
         self.with_env("MINIO_SECRET_KEY", self.secret_key)
-        self.with_command(f"server /data --address :{self.port_to_expose}")
+        self.with_command(f"server /data --address :{self.port}")
 
     def get_client(self, **kwargs) -> Minio:
         """Returns a Minio client to connect to the container.
@@ -62,7 +64,7 @@ class MinioContainer(DockerContainer):
                    https://min.io/docs/minio/linux/developers/python/API.html
         """
         host_ip = self.get_container_host_ip()
-        exposed_port = self.get_exposed_port(self.port_to_expose)
+        exposed_port = self.get_exposed_port(self.port)
         return Minio(
             f"{host_ip}:{exposed_port}",
             access_key=self.access_key,
@@ -79,7 +81,7 @@ class MinioContainer(DockerContainer):
             dict: {`endpoint`: str, `access_key`: str, `secret_key`: str}
         """
         host_ip = self.get_container_host_ip()
-        exposed_port = self.get_exposed_port(self.port_to_expose)
+        exposed_port = self.get_exposed_port(self.port)
         return {
             "endpoint": f"{host_ip}:{exposed_port}",
             "access_key": self.access_key,

--- a/minio/testcontainers/minio/__init__.py
+++ b/minio/testcontainers/minio/__init__.py
@@ -2,6 +2,7 @@ from minio import Minio
 from requests import ConnectionError, Response, get
 
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
@@ -36,7 +37,7 @@ class MinioContainer(DockerContainer):
 
     def __init__(self, image: str = "minio/minio:RELEASE.2022-12-02T19-19-22Z",
                  port: int = 9000, access_key: str = "minioadmin",
-                 secret_key: str = "minioadmin", port_to_expose: None = None, **kwargs) -> None:
+                 secret_key: str = "minioadmin", **kwargs) -> None:
         """
         Args:
             image: Docker image to use for the MinIO container.
@@ -44,8 +45,7 @@ class MinioContainer(DockerContainer):
             access_key: Access key for client connections.
             secret_key: Secret key for client connections.
         """
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(MinioContainer, self).__init__(image, **kwargs)
         self.port = port
         self.access_key = access_key

--- a/mongodb/testcontainers/mongodb/__init__.py
+++ b/mongodb/testcontainers/mongodb/__init__.py
@@ -13,6 +13,7 @@
 import os
 from pymongo import MongoClient
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 from typing import Optional
 
@@ -49,9 +50,8 @@ class MongoDbContainer(DbContainer):
     """
     def __init__(self, image: str = "mongo:latest", port: int = 27017,
                  username: Optional[str] = None, password: Optional[str] = None,
-                 dbname: Optional[str] = None, port_to_expose: None = None, **kwargs) -> None:
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+                 dbname: Optional[str] = None, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(MongoDbContainer, self).__init__(image=image, **kwargs)
         self.username = username or os.environ.get("MONGO_INITDB_ROOT_USERNAME", "test")
         self.password = password or os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")

--- a/mongodb/testcontainers/mongodb/__init__.py
+++ b/mongodb/testcontainers/mongodb/__init__.py
@@ -58,7 +58,6 @@ class MongoDbContainer(DbContainer):
         self.dbname = dbname or os.environ.get("MONGO_DB", "test")
         self.port = port
         self.with_exposed_ports(self.port)
-        self.with_command("mongo")
 
     def _configure(self) -> None:
         self.with_env("MONGO_INITDB_ROOT_USERNAME", self.username)

--- a/mongodb/testcontainers/mongodb/__init__.py
+++ b/mongodb/testcontainers/mongodb/__init__.py
@@ -14,6 +14,7 @@ import os
 from pymongo import MongoClient
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
+from typing import Optional
 
 
 class MongoDbContainer(DbContainer):
@@ -46,26 +47,27 @@ class MongoDbContainer(DbContainer):
             ...    # Find the restaurant document
             ...    cursor = db.restaurants.find({"borough": "Manhattan"})
     """
-    MONGO_INITDB_ROOT_USERNAME = os.environ.get("MONGO_INITDB_ROOT_USERNAME", "test")
-    MONGO_INITDB_ROOT_PASSWORD = os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")
-    MONGO_DB = os.environ.get("MONGO_DB", "test")
-
-    def __init__(self, image: str = "mongo:latest", port_to_expose: int = 27017, **kwargs) -> None:
+    def __init__(self, image: str = "mongo:latest", port_to_expose: int = 27017,
+                 username: Optional[str] = None, password: Optional[str] = None,
+                 dbname: Optional[str] = None, **kwargs) -> None:
         super(MongoDbContainer, self).__init__(image=image, **kwargs)
+        self.username = username or os.environ.get("MONGO_INITDB_ROOT_USERNAME", "test")
+        self.password = password or os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")
+        self.dbname = dbname or os.environ.get("MONGO_DB", "test")
         self.command = "mongo"
         self.port_to_expose = port_to_expose
         self.with_exposed_ports(self.port_to_expose)
 
     def _configure(self) -> None:
-        self.with_env("MONGO_INITDB_ROOT_USERNAME", self.MONGO_INITDB_ROOT_USERNAME)
-        self.with_env("MONGO_INITDB_ROOT_PASSWORD", self.MONGO_INITDB_ROOT_PASSWORD)
-        self.with_env("MONGO_DB", self.MONGO_DB)
+        self.with_env("MONGO_INITDB_ROOT_USERNAME", self.username)
+        self.with_env("MONGO_INITDB_ROOT_PASSWORD", self.password)
+        self.with_env("MONGO_DB", self.dbname)
 
     def get_connection_url(self) -> str:
         return self._create_connection_url(
             dialect='mongodb',
-            username=self.MONGO_INITDB_ROOT_USERNAME,
-            password=self.MONGO_INITDB_ROOT_PASSWORD,
+            username=self.username,
+            password=self.password,
             port=self.port_to_expose,
         )
 

--- a/mongodb/testcontainers/mongodb/__init__.py
+++ b/mongodb/testcontainers/mongodb/__init__.py
@@ -47,16 +47,18 @@ class MongoDbContainer(DbContainer):
             ...    # Find the restaurant document
             ...    cursor = db.restaurants.find({"borough": "Manhattan"})
     """
-    def __init__(self, image: str = "mongo:latest", port_to_expose: int = 27017,
+    def __init__(self, image: str = "mongo:latest", port: int = 27017,
                  username: Optional[str] = None, password: Optional[str] = None,
-                 dbname: Optional[str] = None, **kwargs) -> None:
+                 dbname: Optional[str] = None, port_to_expose: None = None, **kwargs) -> None:
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(MongoDbContainer, self).__init__(image=image, **kwargs)
         self.username = username or os.environ.get("MONGO_INITDB_ROOT_USERNAME", "test")
         self.password = password or os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "test")
         self.dbname = dbname or os.environ.get("MONGO_DB", "test")
-        self.command = "mongo"
-        self.port_to_expose = port_to_expose
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
+        self.with_command("mongo")
 
     def _configure(self) -> None:
         self.with_env("MONGO_INITDB_ROOT_USERNAME", self.username)
@@ -68,7 +70,7 @@ class MongoDbContainer(DbContainer):
             dialect='mongodb',
             username=self.username,
             password=self.password,
-            port=self.port_to_expose,
+            port=self.port,
         )
 
     @wait_container_is_ready()

--- a/mongodb/tests/test_mongodb.py
+++ b/mongodb/tests/test_mongodb.py
@@ -9,8 +9,9 @@ from testcontainers.mongodb import MongoDbContainer
 def test_docker_generic_db():
     with DockerContainer("mongo:latest").with_bind_ports(27017, 27017) as mongo_container:
         def connect():
-            return MongoClient("mongodb://{}:{}".format(mongo_container.get_container_host_ip(),
-                                                        mongo_container.get_exposed_port(27017)))
+            host = mongo_container.get_container_host_ip()
+            port = mongo_container.get_exposed_port(27017)
+            return MongoClient(f"mongodb://{host}:{port}")
 
         db = wait_for(connect).primer
         result = db.restaurants.insert_one(
@@ -55,8 +56,8 @@ def test_docker_run_mongodb():
 
 def test_docker_run_mongodb_connect_without_credentials():
     with MongoDbContainer() as mongo:
-        connection_url = "mongodb://{}:{}".format(mongo.get_container_host_ip(),
-                                                  mongo.get_exposed_port(mongo.port_to_expose))
+        connection_url = f"mongodb://{mongo.get_container_host_ip()}:" \
+            f"{mongo.get_exposed_port(mongo.port)}"
         db = MongoClient(connection_url).test
         with pytest.raises(OperationFailure):
             db.restaurants.insert_one({})

--- a/mssql/testcontainers/mssql/__init__.py
+++ b/mssql/testcontainers/mssql/__init__.py
@@ -27,8 +27,8 @@ class SqlServerContainer(DbContainer):
         raise_for_deprecated_parameter(kwargs, "user", "username")
         super(SqlServerContainer, self).__init__(image, **kwargs)
 
-        self.port_to_expose = port
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
 
         self.password = password or environ.get("SQLSERVER_PASSWORD", "1Secure*Password1")
         self.username = username
@@ -44,5 +44,5 @@ class SqlServerContainer(DbContainer):
     def get_connection_url(self) -> str:
         return super()._create_connection_url(
             dialect=self.dialect, username=self.username, password=self.password,
-            dbname=self.dbname, port=self.port_to_expose
+            dbname=self.dbname, port=self.port
         )

--- a/mssql/testcontainers/mssql/__init__.py
+++ b/mssql/testcontainers/mssql/__init__.py
@@ -1,6 +1,7 @@
 from os import environ
 from typing import Optional
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 
 
 class SqlServerContainer(DbContainer):
@@ -22,11 +23,9 @@ class SqlServerContainer(DbContainer):
 
     def __init__(self, image: str = "mcr.microsoft.com/mssql/server:2019-latest",
                  username: str = "SA", password: Optional[str] = None, port: int = 1433,
-                 dbname: str = "tempdb", dialect: str = 'mssql+pymssql', user: None = None,
-                 **kwargs) -> None:
+                 dbname: str = "tempdb", dialect: str = 'mssql+pymssql', **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "user", "username")
         super(SqlServerContainer, self).__init__(image, **kwargs)
-        if user:
-            raise ValueError("use `username` instead")
 
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)

--- a/mssql/testcontainers/mssql/__init__.py
+++ b/mssql/testcontainers/mssql/__init__.py
@@ -20,27 +20,30 @@ class SqlServerContainer(DbContainer):
             ...        result = connection.execute(sqlalchemy.text("select @@VERSION"))
     """
 
-    def __init__(self, image: str = "mcr.microsoft.com/mssql/server:2019-latest", user: str = "SA",
-                 password: Optional[str] = None, port: int = 1433, dbname: str = "tempdb",
-                 dialect: str = 'mssql+pymssql', **kwargs) -> None:
+    def __init__(self, image: str = "mcr.microsoft.com/mssql/server:2019-latest",
+                 username: str = "SA", password: Optional[str] = None, port: int = 1433,
+                 dbname: str = "tempdb", dialect: str = 'mssql+pymssql', user: None = None,
+                 **kwargs) -> None:
         super(SqlServerContainer, self).__init__(image, **kwargs)
+        if user:
+            raise ValueError("use `username` instead")
 
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
 
-        self.SQLSERVER_PASSWORD = password or environ.get("SQLSERVER_PASSWORD", "1Secure*Password1")
-        self.SQLSERVER_USER = user
-        self.SQLSERVER_DBNAME = dbname
+        self.password = password or environ.get("SQLSERVER_PASSWORD", "1Secure*Password1")
+        self.username = username
+        self.dbname = dbname
         self.dialect = dialect
 
     def _configure(self) -> None:
-        self.with_env("SA_PASSWORD", self.SQLSERVER_PASSWORD)
-        self.with_env("SQLSERVER_USER", self.SQLSERVER_USER)
-        self.with_env("SQLSERVER_DBNAME", self.SQLSERVER_DBNAME)
+        self.with_env("SA_PASSWORD", self.password)
+        self.with_env("SQLSERVER_USER", self.username)
+        self.with_env("SQLSERVER_DBNAME", self.dbname)
         self.with_env("ACCEPT_EULA", 'Y')
 
     def get_connection_url(self) -> str:
         return super()._create_connection_url(
-            dialect=self.dialect, username=self.SQLSERVER_USER, password=self.SQLSERVER_PASSWORD,
-            db_name=self.SQLSERVER_DBNAME, port=self.port_to_expose
+            dialect=self.dialect, username=self.username, password=self.password,
+            db_name=self.dbname, port=self.port_to_expose
         )

--- a/mssql/testcontainers/mssql/__init__.py
+++ b/mssql/testcontainers/mssql/__init__.py
@@ -45,5 +45,5 @@ class SqlServerContainer(DbContainer):
     def get_connection_url(self) -> str:
         return super()._create_connection_url(
             dialect=self.dialect, username=self.username, password=self.password,
-            db_name=self.dbname, port=self.port_to_expose
+            dbname=self.dbname, port=self.port_to_expose
         )

--- a/mysql/testcontainers/mysql/__init__.py
+++ b/mysql/testcontainers/mysql/__init__.py
@@ -47,8 +47,8 @@ class MySqlContainer(DbContainer):
         raise_for_deprecated_parameter(kwargs, "MYSQL_DATABASE", "dbname")
         super(MySqlContainer, self).__init__(image, **kwargs)
 
-        self.port_to_expose = port
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)
         self.username = username or environ.get('MYSQL_USER', 'test')
         self.root_password = root_password or environ.get('MYSQL_ROOT_PASSWORD', 'test')
         self.password = password or environ.get('MYSQL_PASSWORD', 'test')
@@ -70,4 +70,4 @@ class MySqlContainer(DbContainer):
                                               username=self.username,
                                               password=self.password,
                                               dbname=self.dbname,
-                                              port=self.port_to_expose)
+                                              port=self.port)

--- a/mysql/testcontainers/mysql/__init__.py
+++ b/mysql/testcontainers/mysql/__init__.py
@@ -13,6 +13,7 @@
 from os import environ
 from typing import Optional
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 
 
 class MySqlContainer(DbContainer):
@@ -39,18 +40,12 @@ class MySqlContainer(DbContainer):
     """
     def __init__(self, image: str = "mysql:latest", username: Optional[str] = None,
                  root_password: Optional[str] = None, password: Optional[str] = None,
-                 dbname: Optional[str] = None, port: int = 3306, MYSQL_USER: None = None,
-                 MYSQL_ROOT_PASSWORD: None = None, MYSQL_PASSWORD: None = None,
-                 MYSQL_DATABASE: None = None, **kwargs) -> None:
+                 dbname: Optional[str] = None, port: int = 3306, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "MYSQL_USER", "username")
+        raise_for_deprecated_parameter(kwargs, "MYSQL_ROOT_PASSWORD", "root_password")
+        raise_for_deprecated_parameter(kwargs, "MYSQL_PASSWORD", "password")
+        raise_for_deprecated_parameter(kwargs, "MYSQL_DATABASE", "dbname")
         super(MySqlContainer, self).__init__(image, **kwargs)
-        if MYSQL_USER:
-            raise ValueError("use `username` instead of `MYSQL_USER`")
-        if MYSQL_ROOT_PASSWORD:
-            raise ValueError("use `root_password` instead of `MYSQL_ROOT_PASSWORD`")
-        if MYSQL_PASSWORD:
-            raise ValueError("use `password` instead of `MYSQL_PASSWORD`")
-        if MYSQL_DATABASE:
-            raise ValueError("use `dbname` instead of `MYSQL_DATABASE`")
 
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)

--- a/mysql/testcontainers/mysql/__init__.py
+++ b/mysql/testcontainers/mysql/__init__.py
@@ -74,5 +74,5 @@ class MySqlContainer(DbContainer):
         return super()._create_connection_url(dialect="mysql+pymysql",
                                               username=self.username,
                                               password=self.password,
-                                              db_name=self.dbname,
+                                              dbname=self.dbname,
                                               port=self.port_to_expose)

--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -40,7 +40,7 @@ class Neo4jContainer(DbContainer):
     def __init__(self, image: str = "neo4j:latest", *, bolt_port: int = 7687,
                  password: Optional[str] = None, username: Optional[str] = None, **kwargs) -> None:
         super(Neo4jContainer, self).__init__(image, **kwargs)
-        self.username = username or os.environ.get("NEO4J_USER", "password")
+        self.username = username or os.environ.get("NEO4J_USER", "neo4j")
         self.password = password or os.environ.get("NEO4J_PASSWORD", "password")
         self.bolt_port = bolt_port
         self.with_exposed_ports(self.bolt_port)

--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -17,6 +17,7 @@ from neo4j import Driver, GraphDatabase
 
 from testcontainers.core.config import TIMEOUT
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 from typing import Optional
 
@@ -38,10 +39,8 @@ class Neo4jContainer(DbContainer):
             ...     record = result.single()
     """
     def __init__(self, image: str = "neo4j:latest", *, port: int = 7687,
-                 password: Optional[str] = None, username: Optional[str] = None,
-                 bolt_port: None = None, **kwargs) -> None:
-        if bolt_port:
-            raise ValueError("use `port` instead of `bolt_port`")
+                 password: Optional[str] = None, username: Optional[str] = None, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "bolt_port", "port")
         super(Neo4jContainer, self).__init__(image, **kwargs)
         self.username = username or os.environ.get("NEO4J_USER", "neo4j")
         self.password = password or os.environ.get("NEO4J_PASSWORD", "password")

--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -50,11 +50,7 @@ class Neo4jContainer(DbContainer):
         self.with_env("NEO4J_AUTH", f"neo4j/{self.password}")
 
     def get_connection_url(self) -> str:
-        return "{dialect}://{host}:{port}".format(
-            dialect="bolt",
-            host=self.get_container_host_ip(),
-            port=self.get_exposed_port(self.bolt_port),
-        )
+        return f"bolt://{self.get_container_host_ip()}:{self.get_exposed_port(self.bolt_port)}"
 
     @wait_container_is_ready()
     def _connect(self) -> None:

--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -38,7 +38,7 @@ class Neo4jContainer(DbContainer):
             ...     result = session.run("MATCH (n) RETURN n LIMIT 1")
             ...     record = result.single()
     """
-    def __init__(self, image: str = "neo4j:latest", *, port: int = 7687,
+    def __init__(self, image: str = "neo4j:latest", port: int = 7687,
                  password: Optional[str] = None, username: Optional[str] = None, **kwargs) -> None:
         raise_for_deprecated_parameter(kwargs, "bolt_port", "port")
         super(Neo4jContainer, self).__init__(image, **kwargs)

--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -37,20 +37,23 @@ class Neo4jContainer(DbContainer):
             ...     result = session.run("MATCH (n) RETURN n LIMIT 1")
             ...     record = result.single()
     """
-    def __init__(self, image: str = "neo4j:latest", *, bolt_port: int = 7687,
-                 password: Optional[str] = None, username: Optional[str] = None, **kwargs) -> None:
+    def __init__(self, image: str = "neo4j:latest", *, port: int = 7687,
+                 password: Optional[str] = None, username: Optional[str] = None,
+                 bolt_port: None = None, **kwargs) -> None:
+        if bolt_port:
+            raise ValueError("use `port` instead of `bolt_port`")
         super(Neo4jContainer, self).__init__(image, **kwargs)
         self.username = username or os.environ.get("NEO4J_USER", "neo4j")
         self.password = password or os.environ.get("NEO4J_PASSWORD", "password")
-        self.bolt_port = bolt_port
-        self.with_exposed_ports(self.bolt_port)
+        self.port = port
+        self.with_exposed_ports(self.port)
         self._driver = None
 
     def _configure(self) -> None:
         self.with_env("NEO4J_AUTH", f"neo4j/{self.password}")
 
     def get_connection_url(self) -> str:
-        return f"bolt://{self.get_container_host_ip()}:{self.get_exposed_port(self.bolt_port)}"
+        return f"bolt://{self.get_container_host_ip()}:{self.get_exposed_port(self.port)}"
 
     @wait_container_is_ready()
     def _connect(self) -> None:

--- a/nginx/testcontainers/nginx/__init__.py
+++ b/nginx/testcontainers/nginx/__init__.py
@@ -11,13 +11,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 
 
 class NginxContainer(DockerContainer):
-    def __init__(self, image: str = "nginx:latest", port: int = 80, port_to_expose: None = None,
-                 **kwargs) -> None:
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+    def __init__(self, image: str = "nginx:latest", port: int = 80, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(NginxContainer, self).__init__(image, **kwargs)
         self.port = port
         self.with_exposed_ports(self.port)

--- a/nginx/testcontainers/nginx/__init__.py
+++ b/nginx/testcontainers/nginx/__init__.py
@@ -14,7 +14,10 @@ from testcontainers.core.container import DockerContainer
 
 
 class NginxContainer(DockerContainer):
-    def __init__(self, image: str = "nginx:latest", port_to_expose: int = 80, **kwargs) -> None:
+    def __init__(self, image: str = "nginx:latest", port: int = 80, port_to_expose: None = None,
+                 **kwargs) -> None:
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(NginxContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port_to_expose
-        self.with_exposed_ports(self.port_to_expose)
+        self.port = port
+        self.with_exposed_ports(self.port)

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -6,9 +6,7 @@ from testcontainers.nginx import NginxContainer
 def test_docker_run_nginx():
     nginx_container = NginxContainer("nginx:1.13.8")
     with nginx_container as nginx:
-        port = nginx.port_to_expose
-        url = "http://{}:{}/".format(nginx.get_container_host_ip(),
-                                     nginx.get_exposed_port(port))
+        url = f"http://{nginx.get_container_host_ip()}:{nginx.get_exposed_port(nginx.port)}/"
         r = requests.get(url)
         assert (r.status_code == 200)
         assert ('Welcome to nginx!' in r.text)

--- a/opensearch/testcontainers/opensearch/__init__.py
+++ b/opensearch/testcontainers/opensearch/__init__.py
@@ -12,7 +12,8 @@ class OpenSearchContainer(DockerContainer):
     between makes sure that the newly created document is available for search.
 
     The method :code:`get_client` can be used to create a OpenSearch Python Client. The method
-    :code:`get_config` can be used to retrieve the host, port, user, and password of the container.
+    :code:`get_config` can be used to retrieve the host, port, username, and password of the
+    container.
 
     Example:
 
@@ -47,16 +48,16 @@ class OpenSearchContainer(DockerContainer):
 
     def get_config(self) -> dict:
         """This method returns the configuration of the OpenSearch container,
-        including the host, port, user, and password.
+        including the host, port, username, and password.
 
         Returns:
-            dict: {`host`: str, `port`: str, `user`: str, `password`: str}
+            dict: {`host`: str, `port`: str, `username`: str, `password`: str}
         """
 
         return {
             "host": self.get_container_host_ip(),
             "port": self.get_exposed_port(self.port_to_expose),
-            "user": "admin",
+            "username": "admin",
             "password": "admin",
         }
 
@@ -75,7 +76,7 @@ class OpenSearchContainer(DockerContainer):
                     "port": config["port"],
                 }
             ],
-            http_auth=(config["user"], config["password"]),
+            http_auth=(config["username"], config["password"]),
             use_ssl=self.security_enabled,
             verify_certs=verify_certs,
             **kwargs,

--- a/opensearch/testcontainers/opensearch/__init__.py
+++ b/opensearch/testcontainers/opensearch/__init__.py
@@ -29,18 +29,21 @@ class OpenSearchContainer(DockerContainer):
     """
 
     def __init__(self, image: str = "opensearchproject/opensearch:2.4.0",
-                 port_to_expose: int = 9200, security_enabled: bool = False, **kwargs) -> None:
+                 port: int = 9200, security_enabled: bool = False, port_to_expose: None = None,
+                 **kwargs) -> None:
         """
         Args:
             image: Docker image to use for the container.
-            port_to_expose: Port to expose on the container.
+            port: Port to expose on the container.
             security_enabled: :code:`False` disables the security plugin in OpenSearch.
         """
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(OpenSearchContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port_to_expose
+        self.port = port
         self.security_enabled = security_enabled
 
-        self.with_exposed_ports(self.port_to_expose)
+        self.with_exposed_ports(self.port)
         self.with_env("discovery.type", "single-node")
         self.with_env("plugins.security.disabled", "false" if security_enabled else "true")
         if security_enabled:
@@ -56,7 +59,7 @@ class OpenSearchContainer(DockerContainer):
 
         return {
             "host": self.get_container_host_ip(),
-            "port": self.get_exposed_port(self.port_to_expose),
+            "port": self.get_exposed_port(self.port),
             "username": "admin",
             "password": "admin",
         }

--- a/opensearch/testcontainers/opensearch/__init__.py
+++ b/opensearch/testcontainers/opensearch/__init__.py
@@ -2,6 +2,7 @@ from opensearchpy import OpenSearch
 from opensearchpy.exceptions import ConnectionError, TransportError
 
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
 
@@ -29,16 +30,14 @@ class OpenSearchContainer(DockerContainer):
     """
 
     def __init__(self, image: str = "opensearchproject/opensearch:2.4.0",
-                 port: int = 9200, security_enabled: bool = False, port_to_expose: None = None,
-                 **kwargs) -> None:
+                 port: int = 9200, security_enabled: bool = False, **kwargs) -> None:
         """
         Args:
             image: Docker image to use for the container.
             port: Port to expose on the container.
             security_enabled: :code:`False` disables the security plugin in OpenSearch.
         """
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(OpenSearchContainer, self).__init__(image, **kwargs)
         self.port = port
         self.security_enabled = security_enabled

--- a/oracle/testcontainers/oracle/__init__.py
+++ b/oracle/testcontainers/oracle/__init__.py
@@ -27,7 +27,7 @@ class OracleDbContainer(DbContainer):
     def get_connection_url(self) -> str:
         return super()._create_connection_url(
             dialect="oracle", username="system", password="oracle", port=self.container_port,
-            db_name="xe"
+            dbname="xe"
         )
 
     def _configure(self) -> None:

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -38,30 +38,29 @@ class PostgresContainer(DbContainer):
             >>> version
             'PostgreSQL 9.5...'
     """
-    POSTGRES_USER = os.environ.get("POSTGRES_USER", "test")
-    POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "test")
-    POSTGRES_DB = os.environ.get("POSTGRES_DB", "test")
-
-    def __init__(self, image: str = "postgres:latest", port: int = 5432, user: Optional[str] = None,
-                 password: Optional[str] = None, dbname: Optional[str] = None,
-                 driver: str = "psycopg2", **kwargs) -> None:
+    def __init__(self, image: str = "postgres:latest", port: int = 5432,
+                 username: Optional[str] = None, password: Optional[str] = None,
+                 dbname: Optional[str] = None, driver: str = "psycopg2", user: None = None,
+                 **kwargs) -> None:
+        if user:
+            raise ValueError("use `username` instead of `user`")
         super(PostgresContainer, self).__init__(image=image, **kwargs)
-        self.POSTGRES_USER = user or self.POSTGRES_USER
-        self.POSTGRES_PASSWORD = password or self.POSTGRES_PASSWORD
-        self.POSTGRES_DB = dbname or self.POSTGRES_DB
+        self.username = username or os.environ.get("POSTGRES_USER", "test")
+        self.password = password or os.environ.get("POSTGRES_PASSWORD", "test")
+        self.dbname = dbname or os.environ.get("POSTGRES_DB", "test")
         self.port_to_expose = port
         self.driver = driver
 
         self.with_exposed_ports(self.port_to_expose)
 
     def _configure(self) -> None:
-        self.with_env("POSTGRES_USER", self.POSTGRES_USER)
-        self.with_env("POSTGRES_PASSWORD", self.POSTGRES_PASSWORD)
-        self.with_env("POSTGRES_DB", self.POSTGRES_DB)
+        self.with_env("POSTGRES_USER", self.username)
+        self.with_env("POSTGRES_PASSWORD", self.password)
+        self.with_env("POSTGRES_DB", self.dbname)
 
     def get_connection_url(self, host=None) -> str:
         return super()._create_connection_url(
-            dialect="postgresql+{}".format(self.driver), username=self.POSTGRES_USER,
-            password=self.POSTGRES_PASSWORD, db_name=self.POSTGRES_DB, host=host,
+            dialect="postgresql+{}".format(self.driver), username=self.username,
+            password=self.password, db_name=self.dbname, host=host,
             port=self.port_to_expose,
         )

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -61,6 +61,6 @@ class PostgresContainer(DbContainer):
     def get_connection_url(self, host=None) -> str:
         return super()._create_connection_url(
             dialect=f"postgresql+{self.driver}", username=self.username,
-            password=self.password, db_name=self.dbname, host=host,
+            password=self.password, dbname=self.dbname, host=host,
             port=self.port_to_expose,
         )

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -47,10 +47,10 @@ class PostgresContainer(DbContainer):
         self.username = username or os.environ.get("POSTGRES_USER", "test")
         self.password = password or os.environ.get("POSTGRES_PASSWORD", "test")
         self.dbname = dbname or os.environ.get("POSTGRES_DB", "test")
-        self.port_to_expose = port
+        self.port = port
         self.driver = driver
 
-        self.with_exposed_ports(self.port_to_expose)
+        self.with_exposed_ports(self.port)
 
     def _configure(self) -> None:
         self.with_env("POSTGRES_USER", self.username)
@@ -61,5 +61,5 @@ class PostgresContainer(DbContainer):
         return super()._create_connection_url(
             dialect=f"postgresql+{self.driver}", username=self.username,
             password=self.password, dbname=self.dbname, host=host,
-            port=self.port_to_expose,
+            port=self.port,
         )

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -60,7 +60,7 @@ class PostgresContainer(DbContainer):
 
     def get_connection_url(self, host=None) -> str:
         return super()._create_connection_url(
-            dialect="postgresql+{}".format(self.driver), username=self.username,
+            dialect=f"postgresql+{self.driver}", username=self.username,
             password=self.password, db_name=self.dbname, host=host,
             port=self.port_to_expose,
         )

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -13,6 +13,7 @@
 import os
 from typing import Optional
 from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 
 
 class PostgresContainer(DbContainer):
@@ -40,10 +41,8 @@ class PostgresContainer(DbContainer):
     """
     def __init__(self, image: str = "postgres:latest", port: int = 5432,
                  username: Optional[str] = None, password: Optional[str] = None,
-                 dbname: Optional[str] = None, driver: str = "psycopg2", user: None = None,
-                 **kwargs) -> None:
-        if user:
-            raise ValueError("use `username` instead of `user`")
+                 dbname: Optional[str] = None, driver: str = "psycopg2", **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "user", "username")
         super(PostgresContainer, self).__init__(image=image, **kwargs)
         self.username = username or os.environ.get("POSTGRES_USER", "test")
         self.password = password or os.environ.get("POSTGRES_PASSWORD", "test")

--- a/redis/testcontainers/redis/__init__.py
+++ b/redis/testcontainers/redis/__init__.py
@@ -13,6 +13,7 @@
 
 import redis
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready
 from typing import Optional
 
@@ -31,9 +32,8 @@ class RedisContainer(DockerContainer):
             ...     redis_client = redis_container.get_client()
     """
     def __init__(self, image: str = "redis:latest", port: int = 6379,
-                 password: Optional[str] = None, port_to_expose: None = None, **kwargs) -> None:
-        if port_to_expose:
-            raise ValueError("use `port` instead of `port_to_expose`")
+                 password: Optional[str] = None, **kwargs) -> None:
+        raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(RedisContainer, self).__init__(image, **kwargs)
         self.port_to_expose = port
         self.password = password

--- a/redis/testcontainers/redis/__init__.py
+++ b/redis/testcontainers/redis/__init__.py
@@ -14,24 +14,28 @@
 import redis
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
+from typing import Optional
 
 
 class RedisContainer(DockerContainer):
     """
-        Redis container.
+    Redis container.
 
-        Example:
+    Example:
 
-            .. doctest::
+        .. doctest::
 
-                >>> from testcontainers.redis import RedisContainer
+            >>> from testcontainers.redis import RedisContainer
 
-                >>> with RedisContainer() as redis_container:
-                ...     redis_client = redis_container.get_client()
-        """
-    def __init__(self, image="redis:latest", port_to_expose=6379, password=None, **kwargs) -> None:
+            >>> with RedisContainer() as redis_container:
+            ...     redis_client = redis_container.get_client()
+    """
+    def __init__(self, image: str = "redis:latest", port: int = 6379,
+                 password: Optional[str] = None, port_to_expose: None = None, **kwargs) -> None:
+        if port_to_expose:
+            raise ValueError("use `port` instead of `port_to_expose`")
         super(RedisContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port_to_expose
+        self.port_to_expose = port
         self.password = password
         self.with_exposed_ports(self.port_to_expose)
         if self.password:

--- a/redis/testcontainers/redis/__init__.py
+++ b/redis/testcontainers/redis/__init__.py
@@ -35,9 +35,9 @@ class RedisContainer(DockerContainer):
                  password: Optional[str] = None, **kwargs) -> None:
         raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super(RedisContainer, self).__init__(image, **kwargs)
-        self.port_to_expose = port
+        self.port = port
         self.password = password
-        self.with_exposed_ports(self.port_to_expose)
+        self.with_exposed_ports(self.port)
         if self.password:
             self.with_command(f"redis-server --requirepass {self.password}")
 
@@ -59,7 +59,7 @@ class RedisContainer(DockerContainer):
         """
         return redis.Redis(
             host=self.get_container_host_ip(),
-            port=self.get_exposed_port(self.port_to_expose),
+            port=self.get_exposed_port(self.port),
             password=self.password,
             **kwargs,
         )

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -78,24 +78,19 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
-azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-core==1.26.4
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bcrypt==4.0.1
     # via paramiko
@@ -106,7 +101,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -114,13 +108,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.3
     # via
     #   codecov
     #   pytest-cov
@@ -132,6 +126,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -154,19 +150,20 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.17.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -175,7 +172,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.53.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -191,14 +188,14 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -213,7 +210,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -221,26 +218,23 @@ mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.13
+minio==7.1.14
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.7.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -257,7 +251,7 @@ protobuf==3.20.3
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
     # via
@@ -272,7 +266,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -283,7 +277,7 @@ pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.2
+pymysql==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -291,25 +285,26 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.3.0
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.15.3
     # via testcontainers-keycloak
-pytz==2022.7.1
+pytz==2023.3
     # via
-    #   babel
     #   clickhouse-driver
     #   neo4j
 pytz-deprecation-shim==0.1.0.post0
@@ -318,7 +313,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -327,24 +322,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.3
     # via twine
 rsa==4.9
     # via
@@ -354,7 +345,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.3
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -365,6 +356,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -387,7 +379,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.9
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -403,19 +395,20 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   sqlalchemy
-tzdata==2022.7
+tzdata==2023.3
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -431,13 +424,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -78,24 +78,19 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
-azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-core==1.26.4
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
@@ -112,7 +107,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -120,13 +114,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.3
     # via
     #   codecov
     #   pytest-cov
@@ -138,6 +132,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -160,19 +156,20 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.17.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -181,7 +178,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.53.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -197,7 +194,7 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   jsonschema
     #   keyring
@@ -209,12 +206,12 @@ importlib-metadata==6.0.0
     #   sphinx
     #   sqlalchemy
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -229,7 +226,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -237,26 +234,23 @@ mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.13
+minio==7.1.14
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.7.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -273,7 +267,7 @@ protobuf==3.20.3
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
     # via
@@ -288,7 +282,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -299,7 +293,7 @@ pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.2
+pymysql==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -307,7 +301,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.3.0
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -316,14 +310,16 @@ pytest-cov==4.0.0
 python-arango==7.5.6
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.15.3
     # via testcontainers-keycloak
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   babel
     #   clickhouse-driver
@@ -334,7 +330,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -343,24 +339,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.3
     # via twine
 rsa==4.9
     # via
@@ -370,7 +362,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.3
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -381,6 +373,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -403,7 +396,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.9
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -419,7 +412,7 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
@@ -427,17 +420,18 @@ typing-extensions==4.5.0
     # via
     #   async-timeout
     #   azure-core
+    #   azure-storage-blob
     #   h11
     #   importlib-metadata
     #   markdown-it-py
     #   redis
     #   rich
     #   sqlalchemy
-tzdata==2022.7
+tzdata==2023.3
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -453,13 +447,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -78,24 +78,19 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
-azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-core==1.26.4
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
@@ -110,7 +105,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -118,13 +112,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.3
     # via
     #   codecov
     #   pytest-cov
@@ -136,6 +130,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -158,19 +154,20 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.17.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -179,7 +176,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.53.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -195,17 +192,17 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -220,7 +217,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -228,26 +225,23 @@ mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.13
+minio==7.1.14
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.7.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -264,7 +258,7 @@ protobuf==3.20.3
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
     # via
@@ -279,7 +273,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -290,7 +284,7 @@ pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.2
+pymysql==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -298,23 +292,25 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.3.0
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.15.3
     # via testcontainers-keycloak
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   babel
     #   clickhouse-driver
@@ -325,7 +321,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -334,24 +330,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.3
     # via twine
 rsa==4.9
     # via
@@ -361,7 +353,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.3
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -372,6 +364,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -394,7 +387,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.9
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -410,20 +403,21 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   rich
     #   sqlalchemy
-tzdata==2022.7
+tzdata==2023.3
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -439,13 +433,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -78,24 +78,19 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
-azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-core==1.26.4
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bcrypt==4.0.1
     # via paramiko
@@ -106,7 +101,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -114,13 +108,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.3
     # via
     #   codecov
     #   pytest-cov
@@ -132,6 +126,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -154,19 +150,20 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.17.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -175,7 +172,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.53.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -191,7 +188,7 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
@@ -199,7 +196,7 @@ importlib-metadata==6.0.0
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -214,7 +211,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -222,26 +219,23 @@ mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.13
+minio==7.1.14
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.7.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -258,7 +252,7 @@ protobuf==3.20.3
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
     # via
@@ -273,7 +267,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -284,7 +278,7 @@ pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.2
+pymysql==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -292,25 +286,26 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.3.0
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.15.3
     # via testcontainers-keycloak
-pytz==2022.7.1
+pytz==2023.3
     # via
-    #   babel
     #   clickhouse-driver
     #   neo4j
 pytz-deprecation-shim==0.1.0.post0
@@ -319,7 +314,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -328,24 +323,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.3
     # via twine
 rsa==4.9
     # via
@@ -355,7 +346,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.3
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -366,6 +357,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -388,7 +380,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.9
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -404,19 +396,20 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   sqlalchemy
-tzdata==2022.7
+tzdata==2023.3
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -432,13 +425,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/selenium/testcontainers/selenium/__init__.py
+++ b/selenium/testcontainers/selenium/__init__.py
@@ -45,13 +45,14 @@ class BrowserWebDriverContainer(DockerContainer):
         You can easily change browser by passing :code:`DesiredCapabilities.FIREFOX` instead.
     """
 
-    def __init__(self, capabilities: str, image: Optional[str] = None, **kwargs) -> None:
+    def __init__(self, capabilities: str, image: Optional[str] = None, port: int = 4444,
+                 vnc_port: int = 5900, **kwargs) -> None:
         self.capabilities = capabilities
         self.image = image or get_image_name(capabilities)
-        self.port_to_expose = 4444
-        self.vnc_port_to_expose = 5900
+        self.port = port
+        self.vnc_port = vnc_port
         super(BrowserWebDriverContainer, self).__init__(image=self.image, **kwargs)
-        self.with_exposed_ports(self.port_to_expose, self.vnc_port_to_expose)
+        self.with_exposed_ports(self.port, self.vnc_port)
 
     def _configure(self) -> None:
         self.with_env("no_proxy", "localhost")
@@ -68,5 +69,5 @@ class BrowserWebDriverContainer(DockerContainer):
 
     def get_connection_url(self) -> str:
         ip = self.get_container_host_ip()
-        port = self.get_exposed_port(self.port_to_expose)
+        port = self.get_exposed_port(self.port)
         return f'http://{ip}:{port}/wd/hub'

--- a/selenium/testcontainers/selenium/__init__.py
+++ b/selenium/testcontainers/selenium/__init__.py
@@ -10,12 +10,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-"""
-Selenium containers
-===================
-
-Allows to spin up selenium containers for testing with browsers.
-"""
 
 from selenium import webdriver
 from testcontainers.core.container import DockerContainer


### PR DESCRIPTION
Several of the containers currently load environment variables at import time. Consequently, if we create a container, its configuration may not match the current environment variables. Containers also overwrite class variables with instance variables of the same name which can cause confusion. 

This PR 
- removes all class-level variables and loads environment variables at the time the container is created.
- unifies the container API by renaming `user` to `username` and `port_to_expose` to `port` where applicable such that all containers have the same parameter names. The motivation behind renaming `port_to_expose` is that some containers have multiple different ports (cf. #257 and #234). `[specific]_port_to_expose` is just a bit long.

This *will* break a bunch of stuff, but I'm planning to squeeze a lot of this cleanup into the next major release.