### PR TITLE
Neo4j: verify_connectivity for connection test

### DIFF
--- a/neo4j/testcontainers/neo4j/__init__.py
+++ b/neo4j/testcontainers/neo4j/__init__.py
@@ -76,8 +76,7 @@ class Neo4jContainer(DbContainer):
         with self.get_driver() as driver:
             # Drivers may or may not be lazy
             # force them to do a round trip to confirm neo4j is working
-            with driver.session() as session:
-                session.run("RETURN 1").single()
+            driver.verify_connectivity()
 
     def get_driver(self, **kwargs) -> Driver:
         return GraphDatabase.driver(


### PR DESCRIPTION
The driver offers an API specifically crafted to test if it can successfully connect. This tends to exchange less data than a dummy query and hence should be slightly faster.

See also https://neo4j.com/docs/api/python-driver/current/api.html#neo4j.Driver.verify_connectivity