### PR TITLE
Ryuk the reaper

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -19,6 +19,8 @@ import os
 from typing import List, Optional, Union
 import urllib
 
+
+from .labels import create_labels
 from .utils import default_gateway_ip, inside_container, setup_logger
 
 
@@ -44,14 +46,14 @@ class DockerClient:
 
     @ft.wraps(ContainerCollection.run)
     def run(self, image: str, command: Union[str, List[str]] = None,
-            environment: Optional[dict] = None, ports: Optional[dict] = None,
+            environment: Optional[dict] = None, ports: Optional[dict] = None, labels: Optional[dict] = None,
             detach: bool = False, stdout: bool = True, stderr: bool = False, remove: bool = False,
-            **kwargs) -> Container:
+            cleanup_on_exit: bool = True, **kwargs) -> Container:
         container = self.client.containers.run(
             image, command=command, stdout=stdout, stderr=stderr, remove=remove, detach=detach,
-            environment=environment, ports=ports, **kwargs
+            environment=environment, ports=ports, labels=create_labels(image, labels), **kwargs
         )
-        if detach:
+        if detach and cleanup_on_exit:
             atexit.register(_stop_container, container)
         return container
 

--- a/core/testcontainers/core/images.py
+++ b/core/testcontainers/core/images.py
@@ -1,0 +1,4 @@
+from os import environ
+
+
+REAPER_IMAGE = environ.get("RYUK_CONTAINER_IMAGE", "testcontainers/ryuk:0.3.4")

--- a/core/testcontainers/core/labels.py
+++ b/core/testcontainers/core/labels.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+from typing import Optional
+
+from .reaper import REAPER_IMAGE
+
+SESSION_ID: str = str(uuid4())
+LABEL_SESSION_ID = "org.testcontainers.session-id"
+
+def create_labels(image: str, labels: Optional[dict]) -> dict:
+    if labels is None: labels = {}
+
+    if image == REAPER_IMAGE:
+        return labels
+
+    labels[LABEL_SESSION_ID] = SESSION_ID
+    return labels
+

--- a/core/testcontainers/core/reaper.py
+++ b/core/testcontainers/core/reaper.py
@@ -1,0 +1,74 @@
+from os import environ
+from socket import socket
+from typing import TYPE_CHECKING, Optional
+
+
+from .utils import setup_logger
+from .images import REAPER_IMAGE
+from .waiting_utils import wait_for_logs
+from .labels import LABEL_SESSION_ID, SESSION_ID
+
+if TYPE_CHECKING:
+    from .container import DockerContainer
+
+
+logger = setup_logger(__name__)
+
+
+class Reaper:
+    _instance: "Optional[Reaper]" = None
+    _container: "Optional[DockerContainer]" = None
+    _socket: Optional[socket] = None
+
+    @classmethod
+    def get_instance(cls) -> "Reaper":
+        if not Reaper._instance:
+            Reaper._instance = Reaper._create_instance()
+
+        return Reaper._instance
+    
+    @classmethod
+    def delete_instance(cls) -> None:
+        if not Reaper._socket is None:
+            Reaper._socket.close()
+            Reaper._socket = None
+        
+        if not Reaper._container is None:
+            Reaper._container.stop()
+            Reaper._container = None
+
+        if not Reaper._instance is None:
+            Reaper._instance = None
+        
+
+    @classmethod
+    def _create_instance(cls) -> "Reaper":
+        from .container import DockerContainer
+
+        docker_socket = environ.get(
+            "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock"
+        )
+        logger.debug(f"Creating new Reaper for session: {SESSION_ID}")
+
+        Reaper._container = (
+            DockerContainer(REAPER_IMAGE)
+            .with_ryuk(True)
+            .with_name(f"testcontainers-ryuk-{SESSION_ID}")
+            .with_exposed_ports(8080)
+            .with_volume_mapping(docker_socket, "/var/run/docker.sock", "rw")
+            .start()
+        )
+        wait_for_logs(Reaper._container, r".* Started!")
+
+        container_host = Reaper._container.get_container_host_ip()
+        container_port = int(Reaper._container.get_exposed_port(8080))
+
+        Reaper._socket = socket()
+        Reaper._socket.connect((container_host, container_port))
+        Reaper._socket.send(f"label={LABEL_SESSION_ID}={SESSION_ID}\r\n".encode())
+
+        Reaper._instance = Reaper()
+
+        return Reaper._instance
+    
+

--- a/core/tests/test_ryuk.py
+++ b/core/tests/test_ryuk.py
@@ -1,0 +1,21 @@
+import pytest
+
+from testcontainers.core.reaper import Reaper
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+def test_wait_for_reaper():
+    container = DockerContainer("hello-world").with_ryuk(True).start()
+    wait_for_logs(container, "Hello from Docker!")
+    assert Reaper._socket is not None
+    Reaper._socket.close()
+
+    assert Reaper._container is not None
+    wait_for_logs(Reaper._container, r".* Removed 1 .*", timeout=15)
+
+    Reaper.delete_instance()
+
+def test_container_without_ryuk():
+    container = DockerContainer("hello-world").start()
+    wait_for_logs(container, "Hello from Docker!")
+    assert Reaper._instance is None


### PR DESCRIPTION
Add support for resource cleanup with Ryuk, as an alternative to cleanup with context managers or garbage collection (`__del__` dunder method).

Ryuk is used as the default way for resource cleanup in other implementations of `testcontainer` (Java, NodeJS++), but in order to not introduce any breaking changes I have made it explicitly opt-in to use Ryuk instead of other cleanup methods through the `.with_ryuk()` method on the `DockerContainer` class. Perhaps if we want to bring the behaviour closer to the other `testcontainer` implementations in the future, we can consider making Ryuk the default along with a major version bump. 

Behaviour should be fully backwards compatible, only noticable change is that  all containers now get a label used by Ryuk to identify which containers to reap. 