### PR TITLE
Bug/missing cryptography mysql

### DIFF
--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         "testcontainers-core",
         "sqlalchemy",
-        "pymysql"
+        "pymysql[rsa]"
     ],
     python_requires=">=3.7",
 )

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -17,6 +17,17 @@ def test_docker_run_mysql():
                 assert row[0].startswith('5.7.17')
 
 
+@pytest.mark.skipif(is_arm(), reason='mysql container not available for ARM')
+def test_docker_run_mysql_8():
+    config = MySqlContainer('mysql:8')
+    with config as mysql:
+        engine = sqlalchemy.create_engine(mysql.get_connection_url())
+        with engine.begin() as connection:
+            result = connection.execute(sqlalchemy.text("select version()"))
+            for row in result:
+                assert row[0].startswith('8')
+
+
 def test_docker_run_mariadb():
     with MySqlContainer("mariadb:10.6.5").maybe_emulate_amd64() as mariadb:
         engine = sqlalchemy.create_engine(mariadb.get_connection_url())

--- a/requirements/macos-latest-3.10.txt
+++ b/requirements/macos-latest-3.10.txt
@@ -86,7 +86,7 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
@@ -96,15 +96,15 @@ bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -118,13 +118,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
 cx-oracle==8.3.0
     # via testcontainers-oracle
 deprecation==2.1.0
@@ -133,7 +134,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -143,7 +144,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -160,9 +161,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -173,14 +174,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -195,6 +196,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   twine
 iniconfig==2.0.0
     # via pytest
@@ -216,17 +218,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -238,9 +240,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -250,7 +252,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -278,13 +280,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -296,9 +298,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -309,21 +311,19 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -335,14 +335,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -352,7 +352,7 @@ s3transfer==0.6.1
     # via boto3
 scramp==1.4.4
     # via pg8000
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -372,7 +372,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -386,7 +386,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -406,19 +406,18 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/ubuntu-latest-3.10.txt
+++ b/requirements/ubuntu-latest-3.10.txt
@@ -86,7 +86,7 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
@@ -96,15 +96,15 @@ bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -118,13 +118,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
@@ -134,7 +135,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -144,7 +145,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -161,9 +162,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -174,14 +175,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -196,6 +197,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   twine
 iniconfig==2.0.0
     # via pytest
@@ -221,17 +223,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -243,9 +245,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -255,7 +257,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -283,13 +285,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -301,9 +303,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -314,21 +316,19 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -340,14 +340,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -359,7 +359,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -379,7 +379,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -393,7 +393,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -413,19 +413,18 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/ubuntu-latest-3.11.txt
+++ b/requirements/ubuntu-latest-3.11.txt
@@ -79,14 +79,12 @@ asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
     # via trio
-async-timeout==4.0.2
-    # via redis
 attrs==23.1.0
     # via
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
@@ -96,15 +94,15 @@ bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -118,13 +116,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
@@ -134,7 +133,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -144,7 +143,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -158,9 +157,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -171,14 +170,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -193,6 +192,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   twine
 iniconfig==2.0.0
     # via pytest
@@ -218,17 +218,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -240,9 +240,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -252,7 +252,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -280,13 +280,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -298,9 +298,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -311,21 +311,19 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -337,14 +335,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -356,7 +354,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -376,7 +374,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -390,7 +388,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -406,19 +404,18 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/ubuntu-latest-3.7.txt
+++ b/requirements/ubuntu-latest-3.7.txt
@@ -86,31 +86,29 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
 babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
-    # via
-    #   pytz-deprecation-shim
-    #   tzlocal
+    # via tzlocal
 bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
 cached-property==1.5.2
     # via docker-compose
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -124,13 +122,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
@@ -140,7 +139,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -167,9 +166,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -180,14 +179,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -238,17 +237,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -260,9 +259,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -272,7 +271,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -300,13 +299,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -318,7 +317,7 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
 python-arango==7.5.6
     # via testcontainers-arangodb
@@ -331,22 +330,20 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   babel
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -358,14 +355,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -377,7 +374,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -411,7 +408,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -431,7 +428,7 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   async-timeout
     #   azure-core
@@ -439,17 +436,17 @@ typing-extensions==4.5.0
     #   h11
     #   importlib-metadata
     #   markdown-it-py
+    #   pyjwt
     #   redis
     #   rich
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/ubuntu-latest-3.8.txt
+++ b/requirements/ubuntu-latest-3.8.txt
@@ -86,29 +86,27 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
 babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
-    # via
-    #   pytz-deprecation-shim
-    #   tzlocal
+    # via tzlocal
 bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -122,13 +120,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
@@ -138,7 +137,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -148,7 +147,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -165,9 +164,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -178,14 +177,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -200,6 +199,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   sphinx
     #   twine
 importlib-resources==5.12.0
@@ -228,17 +228,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -250,9 +250,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -262,7 +262,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -290,13 +290,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -308,9 +308,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -321,22 +321,20 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   babel
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -348,14 +346,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -367,7 +365,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -387,7 +385,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -401,7 +399,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -421,20 +419,19 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   rich
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/ubuntu-latest-3.9.txt
+++ b/requirements/ubuntu-latest-3.9.txt
@@ -86,7 +86,7 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
@@ -96,15 +96,15 @@ bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -118,13 +118,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.6
     # via testcontainers-clickhouse
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
@@ -134,7 +135,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -144,7 +145,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -161,9 +162,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -174,14 +175,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -196,6 +197,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   sphinx
     #   twine
 iniconfig==2.0.0
@@ -222,17 +224,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -244,9 +246,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -256,7 +258,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -284,13 +286,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -302,9 +304,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -315,21 +317,19 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -341,14 +341,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -360,7 +360,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -380,7 +380,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -394,7 +394,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -414,19 +414,18 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango

--- a/requirements/windows-latest-3.10.txt
+++ b/requirements/windows-latest-3.10.txt
@@ -86,7 +86,7 @@ attrs==23.1.0
     #   jsonschema
     #   outcome
     #   trio
-azure-core==1.26.4
+azure-core==1.27.0
     # via azure-storage-blob
 azure-storage-blob==12.16.0
     # via testcontainers-azurite
@@ -96,15 +96,15 @@ bcrypt==4.0.1
     # via paramiko
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.129
+boto3==1.26.148
     # via testcontainers-localstack
-botocore==1.29.129
+botocore==1.29.148
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   minio
     #   opensearch-py
@@ -124,13 +124,14 @@ colorama==0.4.6
     #   docker-compose
     #   pytest
     #   sphinx
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   pymysql
 cx-oracle==8.3.0
     # via testcontainers-oracle
 deprecation==2.1.0
@@ -139,7 +140,7 @@ distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
     # via pymongo
-docker[ssh]==6.1.0
+docker[ssh]==6.1.3
     # via
     #   docker-compose
     #   testcontainers-core
@@ -149,7 +150,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.19
+docutils==0.20.1
     # via
     #   readme-renderer
     #   sphinx
@@ -166,9 +167,9 @@ flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.17.3
+google-auth==2.19.1
     # via google-api-core
-google-cloud-pubsub==2.16.1
+google-cloud-pubsub==2.17.1
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -179,14 +180,14 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.54.0
+grpcio==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.54.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -201,6 +202,7 @@ imagesize==1.4.1
 importlib-metadata==6.6.0
     # via
     #   keyring
+    #   python-arango
     #   twine
 iniconfig==2.0.0
     # via pytest
@@ -222,17 +224,17 @@ keyring==23.13.1
     # via twine
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.14
+minio==7.1.15
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.8.0
+neo4j==5.9.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
@@ -244,9 +246,9 @@ packaging==23.1
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.1.0
+paramiko==3.2.0
     # via docker
-pg8000==1.29.4
+pg8000==1.29.6
     # via -r requirements.in
 pika==1.3.2
     # via testcontainers-rabbitmq
@@ -256,7 +258,7 @@ pluggy==1.0.0
     # via pytest
 proto-plus==1.22.2
     # via google-cloud-pubsub
-protobuf==4.22.4
+protobuf==4.23.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
@@ -284,13 +286,13 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via python-arango
 pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.3
+pymysql[rsa]==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -302,9 +304,9 @@ pytest==7.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-python-arango==7.5.7
+python-arango==7.5.8
     # via testcontainers-arangodb
 python-dateutil==2.8.2
     # via
@@ -315,14 +317,12 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.16.1
+python-keycloak==3.0.0
     # via testcontainers-keycloak
 pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pywin32==306
     # via docker
 pywin32-ctypes==0.2.0
@@ -331,9 +331,9 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.4
+redis==4.5.5
     # via testcontainers-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   azure-core
     #   docker
@@ -345,14 +345,14 @@ requests==2.30.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 rsa==4.9
     # via
@@ -362,7 +362,7 @@ s3transfer==0.6.1
     # via boto3
 scramp==1.4.4
     # via pg8000
-selenium==4.9.0
+selenium==4.9.1
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -382,7 +382,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via trio
-sphinx==7.0.0
+sphinx==7.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -396,7 +396,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.12
+sqlalchemy==2.0.15
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -416,21 +416,20 @@ trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
 tzdata==2023.3
-    # via
-    #   pytz-deprecation-shim
-    #   tzlocal
-tzlocal==4.3
+    # via tzlocal
+tzlocal==5.0.1
     # via clickhouse-driver
-urllib3[socks]==1.26.15
+urllib3[socks]==1.26.16
     # via
     #   botocore
     #   docker
+    #   google-auth
     #   minio
     #   opensearch-py
     #   python-arango


### PR DESCRIPTION
When installed into a clean environment, testcontainers-mysql requires `cryptography` package to authenticate with "mock db". This pull requests specifies the requirement for `pymysql` (which is the reason why cryptography is required):

https://github.com/PyMySQL/PyMySQL/blob/b1399c95bcde8ef73cbc3a6d4e8bf767094bbd9e/pyproject.toml#L31

This happens only for mysql:8, mysql:5 doesn't have this issue.