### PR TITLE
Add support for IBM Db2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           - clickhouse
           - compose
           - core
+          - db2
           - elasticsearch
           - google
           - kafka

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ testcontainers-python facilitates the use of Docker containers for functional an
     azurite/README
     clickhouse/README
     compose/README
+    db2/README
     elasticsearch/README
     google/README
     kafka/README

--- a/db2/README.rst
+++ b/db2/README.rst
@@ -1,0 +1,1 @@
+.. autoclass:: testcontainers.db2.Db2Container

--- a/db2/setup.py
+++ b/db2/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/testcontainers/testcontainers-python",
     install_requires=[
         "testcontainers-core",
-        "sqlalchemy",
+        "sqlalchemy<2",
         "ibm_db_sa",
     ],
     python_requires=">=3.7",

--- a/db2/setup.py
+++ b/db2/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/testcontainers/testcontainers-python",
     install_requires=[
         "testcontainers-core",
-        "sqlalchemy<2",
+        "sqlalchemy",
         "ibm_db_sa",
     ],
     python_requires=">=3.7",

--- a/db2/setup.py
+++ b/db2/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, find_namespace_packages
+
+description = "IBM Db2 component of testcontainers-python."
+
+setup(
+    name="testcontainers-db2",
+    version="0.0.1rc1",
+    packages=find_namespace_packages(),
+    description=description,
+    long_description=description,
+    long_description_content_type="text/x-rst",
+    url="https://github.com/testcontainers/testcontainers-python",
+    install_requires=[
+        "testcontainers-core",
+        "sqlalchemy",
+        "ibm_db_sa",
+    ],
+    python_requires=">=3.7",
+)

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -40,7 +40,6 @@ class Db2Container(DbContainer):
             True
             
     """
-
     TIMEOUT = 1_000
 
     def __init__(

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -29,15 +29,15 @@ class Db2Container(DbContainer):
             >>> from testcontainers.db2 import Db2Container
 
             >>> with tempfile.TemporaryDirectory() as tempdir:
-            >>>     container = Db2Container(privileged=True)
+            >>>     container = Db2Container("ibmcom/db2:11.5.7.0", privileged=True)
             ...     with container.with_volume_mapping(tempdir, "/database", mode="rw") as db2:
             ...         engine = sqlalchemy.create_engine(db2.get_connection_url())
             ...         with engine.connect() as conn:
             ...             query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
             ...             result = conn.execute(query)
             ...             version = result.scalar()
-            >>> version.startswith("DB2 v")
-            True
+            >>> version
+            'DB2 v11.5.7.0'
             
     """
     TIMEOUT = 1_000

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -24,18 +24,15 @@ class Db2Container(DbContainer):
 
         .. doctest::
 
-            >>> import tempfile
             >>> import sqlalchemy
             >>> from testcontainers.db2 import Db2Container
 
-            >>> with tempfile.TemporaryDirectory() as tempdir:
-            >>>     container = Db2Container("ibmcom/db2:11.5.7.0", privileged=True)
-            ...     with container.with_volume_mapping(tempdir, "/database", mode="rw") as db2:
-            ...         engine = sqlalchemy.create_engine(db2.get_connection_url())
-            ...         with engine.connect() as conn:
-            ...             query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
-            ...             result = conn.execute(query)
-            ...             version = result.scalar()
+            >>> with Db2Container("ibmcom/db2:11.5.7.0", privileged=True) as db2:
+            ...     engine = sqlalchemy.create_engine(db2.get_connection_url())
+            ...     with engine.connect() as conn:
+            ...         query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
+            ...         result = conn.execute(query)
+            ...         version = result.scalar()
             >>> version
             'DB2 v11.5.7.0'
             
@@ -63,6 +60,7 @@ class Db2Container(DbContainer):
         self.with_env("DB2INST1_PASSWORD", self.password)
         self.with_env("DBNAME", self.database)
         self.with_env("LICENSE", "accept")
+        self.with_env("PERSISTENT_HOME", "false")
         self.with_env("ARCHIVE_LOGS", "false") # reduces start-up time
         self.with_env("AUTOCONFIG", "false") # reduces start-up time
 

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -23,8 +23,8 @@ class Db2Container(DbContainer):
             >>> import sqlalchemy
             >>> from testcontainers.db2 import Db2Container
             >>> from testcontainers.core.waiting_utils import wait_for_logs
-            >>> with Db2ontainer() as db2:
-            >>>     wait_for_logs(es, "(*) Setup has completed")
+            >>> with Db2Container() as db2:
+            >>>     wait_for_logs(db2, "(*) Setup has completed")
             ...     engine = sqlalchemy.create_engine(db2.get_connection_url())
             ...     with engine.begin() as connection:
             ...         result = connection.execute(sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO"))

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -1,0 +1,71 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import os
+from typing import Optional
+from testcontainers.core.generic import DbContainer
+
+class Db2Container(DbContainer):
+    """
+    IBM Db2 database container.
+
+    Example:
+
+            >>> import sqlalchemy
+            >>> from testcontainers.db2 import Db2Container
+            >>> from testcontainers.core.waiting_utils import wait_for_logs
+            >>> with Db2ontainer() as db2:
+            >>>     wait_for_logs(es, "(*) Setup has completed")
+            ...     engine = sqlalchemy.create_engine(db2.get_connection_url())
+            ...     with engine.begin() as connection:
+            ...         result = connection.execute(sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO"))
+            ...         version, = result.fetchone()
+    """
+    DB2_USER = os.environ.get("DB2_USER", "test")
+    DB2_PASSWORD = os.environ.get("DB2_PASSWORD", "test")
+    DB2_DATABASE = os.environ.get("DB2_DATABASE", "test")
+
+    def __init__(
+        self, 
+        image: str = "ibmcom/db2:latest", 
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        database: Optional[str] = None, 
+        port: int = 50_000, 
+        **kwargs
+    ) -> None:
+        super(Db2Container, self).__init__(image=image, **kwargs)
+        self.DB2_USER = user or self.DB2_USER
+        self.DB2_PASSWORD = password or self.DB2_PASSWORD
+        self.DB2_DATABASE = database or self.DB2_DATABASE
+        self.port_to_expose = port
+
+        self.with_exposed_ports(self.port_to_expose)
+
+    def _configure(self) -> None:
+        self.with_env("DB2INSTANCE", self.DB2_USER)
+        self.with_env("DB2INST1_PASSWORD", self.DB2_PASSWORD)
+        self.with_env("DBNAME", self.DB2_DATABASE)
+        self.with_env("LICENSE", "accept")
+        # the following settings reduce container start-up time
+        self.with_env("ARCHIVE_LOGS", "false")
+        self.with_env("AUTOCONFIG", "false")
+
+    def get_connection_url(self, host=None) -> str:
+        return super()._create_connection_url(
+            dialect="db2", 
+            username=self.DB2_USER, 
+            password=self.DB2_PASSWORD, 
+            db_name=self.DB2_DATABASE, 
+            host=host,
+            port=self.port_to_expose,
+        )

--- a/db2/testcontainers/db2/__init__.py
+++ b/db2/testcontainers/db2/__init__.py
@@ -40,31 +40,29 @@ class Db2Container(DbContainer):
             True
             
     """
-    DB2_USER = os.environ.get("DB2_USER", "test")
-    DB2_PASSWORD = os.environ.get("DB2_PASSWORD", "test")
-    DB2_DATABASE = os.environ.get("DB2_DATABASE", "test")
+
     TIMEOUT = 1_000
 
     def __init__(
         self, 
         image: str = "ibmcom/db2:latest", 
-        user: Optional[str] = None,
+        username: Optional[str] = None,
         password: Optional[str] = None,
         database: Optional[str] = None, 
         port: int = 50_000, 
         **kwargs
     ) -> None:
         super(Db2Container, self).__init__(image=image, **kwargs)
-        self.DB2_USER = user or self.DB2_USER
-        self.DB2_PASSWORD = password or self.DB2_PASSWORD
-        self.DB2_DATABASE = database or self.DB2_DATABASE
+        self.username = username or os.environ.get("DB2_USER", "test")
+        self.password = password or os.environ.get("DB2_PASSWORD", "test")
+        self.database = database or os.environ.get("DB2_DATABASE", "test")
         self.port_to_expose = port
         self.with_exposed_ports(self.port_to_expose)
 
     def _configure(self) -> None:
-        self.with_env("DB2INSTANCE", self.DB2_USER)
-        self.with_env("DB2INST1_PASSWORD", self.DB2_PASSWORD)
-        self.with_env("DBNAME", self.DB2_DATABASE)
+        self.with_env("DB2INSTANCE", self.username)
+        self.with_env("DB2INST1_PASSWORD", self.password)
+        self.with_env("DBNAME", self.database)
         self.with_env("LICENSE", "accept")
         self.with_env("ARCHIVE_LOGS", "false") # reduces start-up time
         self.with_env("AUTOCONFIG", "false") # reduces start-up time
@@ -72,9 +70,9 @@ class Db2Container(DbContainer):
     def get_connection_url(self, host=None) -> str:
         return super()._create_connection_url(
             dialect="db2", 
-            username=self.DB2_USER, 
-            password=self.DB2_PASSWORD, 
-            db_name=self.DB2_DATABASE, 
+            username=self.username, 
+            password=self.password, 
+            db_name=self.database, 
             host=host,
             port=self.port_to_expose,
         )

--- a/db2/tests/test_db2.py
+++ b/db2/tests/test_db2.py
@@ -1,0 +1,18 @@
+import pytest
+import tempfile
+import sqlalchemy
+from testcontainers.core.utils import is_arm
+from testcontainers.db2 import Db2Container
+
+
+@pytest.mark.skipif(is_arm(), reason='ibm_db_sa adapter not compatible with ARM64')
+def test_docker_run_db2():
+    with tempfile.TemporaryDirectory() as tempdir:
+        config = Db2Container("ibmcom/db2:11.5.7.0", privileged=True, platform="linux/amd64")
+        with config.with_volume_mapping(tempdir, "/database", mode="rw") as db2:
+            engine = sqlalchemy.create_engine(db2.get_connection_url())
+            with engine.connect() as conn:
+                query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
+                result = conn.execute(query)
+                version = result.scalar()
+                assert version == "DB2 v11.5.7.0"

--- a/db2/tests/test_db2.py
+++ b/db2/tests/test_db2.py
@@ -4,7 +4,6 @@ import sqlalchemy
 from testcontainers.core.utils import is_arm
 from testcontainers.db2 import Db2Container
 
-
 @pytest.mark.skipif(is_arm(), reason='ibm_db_sa adapter not compatible with ARM64')
 def test_docker_run_db2():
     with tempfile.TemporaryDirectory() as tempdir:

--- a/db2/tests/test_db2.py
+++ b/db2/tests/test_db2.py
@@ -1,17 +1,14 @@
 import pytest
-import tempfile
 import sqlalchemy
 from testcontainers.core.utils import is_arm
 from testcontainers.db2 import Db2Container
 
 @pytest.mark.skipif(is_arm(), reason='ibm_db_sa adapter not compatible with ARM64')
 def test_docker_run_db2():
-    with tempfile.TemporaryDirectory() as tempdir:
-        config = Db2Container("ibmcom/db2:11.5.7.0", privileged=True)
-        with config.with_volume_mapping(tempdir, "/database", mode="rw") as db2:
-            engine = sqlalchemy.create_engine(db2.get_connection_url())
-            with engine.connect() as conn:
-                query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
-                result = conn.execute(query)
-                version = result.scalar()
-                assert version == "DB2 v11.5.7.0"
+    with Db2Container("ibmcom/db2:11.5.7.0", privileged=True) as db2:
+        engine = sqlalchemy.create_engine(db2.get_connection_url())
+        with engine.connect() as conn:
+            query = sqlalchemy.text("SELECT SERVICE_LEVEL FROM SYSIBMADM.ENV_INST_INFO")
+            result = conn.execute(query)
+            version = result.scalar()
+            assert version == "DB2 v11.5.7.0"

--- a/db2/tests/test_db2.py
+++ b/db2/tests/test_db2.py
@@ -8,7 +8,7 @@ from testcontainers.db2 import Db2Container
 @pytest.mark.skipif(is_arm(), reason='ibm_db_sa adapter not compatible with ARM64')
 def test_docker_run_db2():
     with tempfile.TemporaryDirectory() as tempdir:
-        config = Db2Container("ibmcom/db2:11.5.7.0", privileged=True, platform="linux/amd64")
+        config = Db2Container("ibmcom/db2:11.5.7.0", privileged=True)
         with config.with_volume_mapping(tempdir, "/database", mode="rw") as db2:
             engine = sqlalchemy.create_engine(db2.get_connection_url())
             with engine.connect() as conn:

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@
 -e file:clickhouse
 -e file:core
 -e file:compose
+-e file:db2
 -e file:elasticsearch
 -e file:google
 -e file:kafka

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -321,7 +321,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -387,7 +387,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.7
+sqlalchemy==1.4.47
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -413,7 +413,6 @@ typing-extensions==4.5.0
     # via
     #   azure-core
     #   azure-storage-blob
-    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -387,7 +387,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.47
+sqlalchemy==2.0.7
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -413,6 +413,7 @@ typing-extensions==4.5.0
     # via
     #   azure-core
     #   azure-storage-blob
+    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -22,6 +22,7 @@
     #   testcontainers-azurite
     #   testcontainers-clickhouse
     #   testcontainers-compose
+    #   testcontainers-db2
     #   testcontainers-elasticsearch
     #   testcontainers-gcp
     #   testcontainers-kafka
@@ -39,6 +40,8 @@
     #   testcontainers-rabbitmq
     #   testcontainers-redis
     #   testcontainers-selenium
+-e file:db2
+    # via -r requirements.in
 -e file:elasticsearch
     # via -r requirements.in
 -e file:google
@@ -78,9 +81,7 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
@@ -90,12 +91,10 @@ attrs==22.2.0
     #   pytest
     #   trio
 azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bcrypt==4.0.1
     # via paramiko
@@ -106,7 +105,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -114,13 +112,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.2
     # via
     #   codecov
     #   pytest-cov
@@ -132,6 +130,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -154,15 +154,16 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.16.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
@@ -175,7 +176,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -185,20 +186,24 @@ grpcio-status==1.48.2
     # via google-api-core
 h11==0.14.0
     # via wsproto
+ibm-db==3.1.4
+    # via ibm-db-sa
+ibm-db-sa==0.3.9
+    # via testcontainers-db2
 idna==3.4
     # via
     #   requests
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   keyring
     #   twine
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -213,7 +218,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -223,24 +228,21 @@ mdurl==0.1.2
     # via markdown-it-py
 minio==7.1.13
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.6.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -291,25 +293,26 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.14.0
     # via testcontainers-keycloak
 pytz==2022.7.1
     # via
-    #   babel
     #   clickhouse-driver
     #   neo4j
 pytz-deprecation-shim==0.1.0.post0
@@ -327,24 +330,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 rsa==4.9
     # via
@@ -354,7 +353,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.2
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -365,6 +364,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -387,8 +387,10 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.7
     # via
+    #   ibm-db-sa
+    #   testcontainers-db2
     #   testcontainers-mssql
     #   testcontainers-mysql
     #   testcontainers-oracle
@@ -403,19 +405,20 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -431,13 +434,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -338,7 +338,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -404,7 +404,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.7
+sqlalchemy==1.4.47
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -436,7 +436,6 @@ typing-extensions==4.5.0
     #   markdown-it-py
     #   redis
     #   rich
-    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -22,6 +22,7 @@
     #   testcontainers-azurite
     #   testcontainers-clickhouse
     #   testcontainers-compose
+    #   testcontainers-db2
     #   testcontainers-elasticsearch
     #   testcontainers-gcp
     #   testcontainers-kafka
@@ -39,6 +40,8 @@
     #   testcontainers-rabbitmq
     #   testcontainers-redis
     #   testcontainers-selenium
+-e file:db2
+    # via -r requirements.in
 -e file:elasticsearch
     # via -r requirements.in
 -e file:google
@@ -78,9 +81,7 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
@@ -90,12 +91,10 @@ attrs==22.2.0
     #   pytest
     #   trio
 azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
@@ -112,7 +111,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -120,13 +118,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.2
     # via
     #   codecov
     #   pytest-cov
@@ -138,6 +136,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -160,15 +160,16 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.16.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
@@ -181,7 +182,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -191,13 +192,17 @@ grpcio-status==1.48.2
     # via google-api-core
 h11==0.14.0
     # via wsproto
+ibm-db==3.1.4
+    # via ibm-db-sa
+ibm-db-sa==0.3.9
+    # via testcontainers-db2
 idna==3.4
     # via
     #   requests
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   jsonschema
     #   keyring
@@ -209,12 +214,12 @@ importlib-metadata==6.0.0
     #   sphinx
     #   sqlalchemy
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -229,7 +234,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -239,24 +244,21 @@ mdurl==0.1.2
     # via markdown-it-py
 minio==7.1.13
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.6.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -307,7 +309,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -316,12 +318,14 @@ pytest-cov==4.0.0
 python-arango==7.5.6
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.14.0
     # via testcontainers-keycloak
 pytz==2022.7.1
     # via
@@ -343,24 +347,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 rsa==4.9
     # via
@@ -370,7 +370,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.2
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -381,6 +381,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -403,8 +404,10 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.7
     # via
+    #   ibm-db-sa
+    #   testcontainers-db2
     #   testcontainers-mssql
     #   testcontainers-mysql
     #   testcontainers-oracle
@@ -419,7 +422,7 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
@@ -427,6 +430,7 @@ typing-extensions==4.5.0
     # via
     #   async-timeout
     #   azure-core
+    #   azure-storage-blob
     #   h11
     #   importlib-metadata
     #   markdown-it-py
@@ -435,9 +439,9 @@ typing-extensions==4.5.0
     #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -453,13 +457,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -404,7 +404,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.47
+sqlalchemy==2.0.7
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -436,6 +436,7 @@ typing-extensions==4.5.0
     #   markdown-it-py
     #   redis
     #   rich
+    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -395,7 +395,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.47
+sqlalchemy==2.0.7
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -422,6 +422,7 @@ typing-extensions==4.5.0
     #   azure-core
     #   azure-storage-blob
     #   rich
+    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -329,7 +329,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -395,7 +395,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.7
+sqlalchemy==1.4.47
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -422,7 +422,6 @@ typing-extensions==4.5.0
     #   azure-core
     #   azure-storage-blob
     #   rich
-    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -22,6 +22,7 @@
     #   testcontainers-azurite
     #   testcontainers-clickhouse
     #   testcontainers-compose
+    #   testcontainers-db2
     #   testcontainers-elasticsearch
     #   testcontainers-gcp
     #   testcontainers-kafka
@@ -39,6 +40,8 @@
     #   testcontainers-rabbitmq
     #   testcontainers-redis
     #   testcontainers-selenium
+-e file:db2
+    # via -r requirements.in
 -e file:elasticsearch
     # via -r requirements.in
 -e file:google
@@ -78,9 +81,7 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
@@ -90,12 +91,10 @@ attrs==22.2.0
     #   pytest
     #   trio
 azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 backports-zoneinfo==0.2.1
     # via
@@ -110,7 +109,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -118,13 +116,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.2
     # via
     #   codecov
     #   pytest-cov
@@ -136,6 +134,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -158,15 +158,16 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.16.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
@@ -179,7 +180,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -189,23 +190,27 @@ grpcio-status==1.48.2
     # via google-api-core
 h11==0.14.0
     # via wsproto
+ibm-db==3.1.4
+    # via ibm-db-sa
+ibm-db-sa==0.3.9
+    # via testcontainers-db2
 idna==3.4
     # via
     #   requests
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -220,7 +225,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -230,24 +235,21 @@ mdurl==0.1.2
     # via markdown-it-py
 minio==7.1.13
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.6.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -298,21 +300,23 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.14.0
     # via testcontainers-keycloak
 pytz==2022.7.1
     # via
@@ -334,24 +338,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 rsa==4.9
     # via
@@ -361,7 +361,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.2
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -372,6 +372,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -394,8 +395,10 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.7
     # via
+    #   ibm-db-sa
+    #   testcontainers-db2
     #   testcontainers-mssql
     #   testcontainers-mysql
     #   testcontainers-oracle
@@ -410,20 +413,21 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   rich
     #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -439,13 +443,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -22,6 +22,7 @@
     #   testcontainers-azurite
     #   testcontainers-clickhouse
     #   testcontainers-compose
+    #   testcontainers-db2
     #   testcontainers-elasticsearch
     #   testcontainers-gcp
     #   testcontainers-kafka
@@ -39,6 +40,8 @@
     #   testcontainers-rabbitmq
     #   testcontainers-redis
     #   testcontainers-selenium
+-e file:db2
+    # via -r requirements.in
 -e file:elasticsearch
     # via -r requirements.in
 -e file:google
@@ -78,9 +81,7 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
@@ -90,12 +91,10 @@ attrs==22.2.0
     #   pytest
     #   trio
 azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via testcontainers-azurite
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bcrypt==4.0.1
     # via paramiko
@@ -106,7 +105,6 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   minio
-    #   msrest
     #   opensearch-py
     #   requests
     #   selenium
@@ -114,13 +112,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 codecov==2.1.12
     # via -r requirements.in
-coverage[toml]==7.1.0
+coverage[toml]==7.2.2
     # via
     #   codecov
     #   pytest-cov
@@ -132,6 +130,8 @@ cryptography==36.0.2
     #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
+deprecation==2.1.0
+    # via python-keycloak
 distro==1.8.0
     # via docker-compose
 dnspython==2.3.0
@@ -154,15 +154,16 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   pytest
     #   trio
+    #   trio-websocket
 flake8==3.7.9
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.0
+google-auth==2.16.2
     # via google-api-core
 google-cloud-pubsub==1.7.2
     # via testcontainers-gcp
@@ -175,7 +176,7 @@ greenlet==2.0.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -185,13 +186,17 @@ grpcio-status==1.48.2
     # via google-api-core
 h11==0.14.0
     # via wsproto
+ibm-db==3.1.4
+    # via ibm-db-sa
+ibm-db-sa==0.3.9
+    # via testcontainers-db2
 idna==3.4
     # via
     #   requests
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   keyring
     #   sphinx
@@ -199,7 +204,7 @@ importlib-metadata==6.0.0
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
@@ -214,7 +219,7 @@ kafka-python==2.0.2
     # via testcontainers-kafka
 keyring==23.13.1
     # via twine
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
     # via jinja2
@@ -224,24 +229,21 @@ mdurl==0.1.2
     # via markdown-it-py
 minio==7.1.13
     # via testcontainers-minio
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-msrest==0.7.1
-    # via azure-storage-blob
-neo4j==5.5.0
+neo4j==5.6.0
     # via testcontainers-neo4j
-oauthlib==3.2.2
-    # via requests-oauthlib
-opensearch-py==2.1.1
+opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
 packaging==23.0
     # via
+    #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -292,25 +294,26 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
     # via -r requirements.in
-python-arango==7.5.6
+python-arango==7.5.7
     # via testcontainers-arangodb
 python-dateutil==2.8.2
-    # via pg8000
+    # via
+    #   opensearch-py
+    #   pg8000
 python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.12.0
+python-keycloak==2.14.0
     # via testcontainers-keycloak
 pytz==2022.7.1
     # via
-    #   babel
     #   clickhouse-driver
     #   neo4j
 pytz-deprecation-shim==0.1.0.post0
@@ -328,24 +331,20 @@ requests==2.28.2
     #   docker
     #   docker-compose
     #   google-api-core
-    #   msrest
     #   opensearch-py
     #   python-arango
     #   python-keycloak
-    #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-oauthlib==1.3.1
-    # via msrest
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   python-arango
     #   python-keycloak
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 rsa==4.9
     # via
@@ -355,7 +354,7 @@ scramp==1.4.4
     # via pg8000
 secretstorage==3.3.3
     # via keyring
-selenium==4.8.0
+selenium==4.8.2
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -366,6 +365,7 @@ six==1.16.0
     #   google-auth
     #   isodate
     #   jsonschema
+    #   opensearch-py
     #   python-dateutil
     #   websocket-client
 sniffio==1.3.0
@@ -388,8 +388,10 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.3
+sqlalchemy==2.0.7
     # via
+    #   ibm-db-sa
+    #   testcontainers-db2
     #   testcontainers-mssql
     #   testcontainers-mysql
     #   testcontainers-oracle
@@ -404,19 +406,20 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
 typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -432,13 +435,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via testcontainers-core
 wsproto==1.2.0
     # via trio-websocket
-zipp==3.13.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -322,7 +322,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -388,7 +388,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.7
+sqlalchemy==1.4.47
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -414,7 +414,6 @@ typing-extensions==4.5.0
     # via
     #   azure-core
     #   azure-storage-blob
-    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -388,7 +388,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.47
+sqlalchemy==2.0.7
     # via
     #   ibm-db-sa
     #   testcontainers-db2
@@ -414,6 +414,7 @@ typing-extensions==4.5.0
     # via
     #   azure-core
     #   azure-storage-blob
+    #   sqlalchemy
 tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.3


### PR DESCRIPTION
Adds support for containers created from the `ibmcom/db2` image.

## Notes

- The SQLAlchemy adapter `ibm_db_sa` used for Db2 [**does not yet support SQLAlchemy 2.0**](https://github.com/ibmdb/python-ibmdbsa/issues/118#issuecomment-1471398128) (the devs are currently working on it), so this PR won't be able to go in until then, but thought I'd still get the review meanwhile. Alternatively, can I specify `sqlalchemy<2` in the `setup.py` that I created?
- The container takes ages to start up, sometimes around 15 minutes on my machine, so I'm not sure we want it to run as part of the unit tests as it might hold everything up.
- The container must run in privileged mode.

## Checks

- [x] Create a new feature directory and populate it with the package structure [described in the documentation](https://testcontainers-python.readthedocs.io/en/latest/#package-structure). Copying one of the existing features is likely the best way to get started.
- [x] Implement the new feature (typically in `__init__.py`) and corresponding tests.
- [x] Add a line `-e file:[feature name]` to `requirements.in` and run `make requirements`. This command will find any new requirements and generate lock files to ensure reproducible builds (see the [pip-tools documentation](https://pip-tools.readthedocs.io/en/latest/) for details). Then run `pip install -r requirements/[your python version].txt` to install the new requirements.
- [x] Update the feature `README.rst` and add it to the table of contents (`toctree` directive) in the top-level `README.rst`.
- [x] Add a line `[feature name]` to the list of components in the  GitHub Action workflow in `.github/workflows/main.yml` to run tests, build, and publish your package when pushed to the `master` branch.
- [x] Rebase your development branch on `master` (or merge `master` into your development branch).