### PR TITLE
Remove `codecov` requirement.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,6 @@
 -e file:rabbitmq
 -e file:redis
 -e file:selenium
-codecov>=2.1.0
 cryptography<37
 flake8<3.8.0  # 3.8.0 adds a dependency on importlib-metadata which conflicts with other packages.
 pg8000

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -112,11 +112,9 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-codecov==2.1.12
     # via -r requirements.in
 coverage[toml]==7.2.3
     # via
-    #   codecov
     #   pytest-cov
 cryptography==36.0.2
     # via
@@ -318,7 +316,6 @@ redis==4.5.4
 requests==2.28.2
     # via
     #   azure-core
-    #   codecov
     #   docker
     #   docker-compose
     #   google-api-core

--- a/requirements/3.11.txt
+++ b/requirements/3.11.txt
@@ -115,11 +115,9 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-codecov==2.1.12
     # via -r requirements.in
 coverage[toml]==7.2.1
     # via
-    #   codecov
     #   pytest-cov
 cryptography==36.0.2
     # via
@@ -309,7 +307,6 @@ redis==4.5.1
 requests==2.28.2
     # via
     #   azure-core
-    #   codecov
     #   docker
     #   docker-compose
     #   google-api-core

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -118,11 +118,8 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-codecov==2.1.12
-    # via -r requirements.in
 coverage[toml]==7.2.3
     # via
-    #   codecov
     #   pytest-cov
 cryptography==36.0.2
     # via
@@ -335,7 +332,6 @@ redis==4.5.4
 requests==2.28.2
     # via
     #   azure-core
-    #   codecov
     #   docker
     #   docker-compose
     #   google-api-core

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -116,11 +116,9 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-codecov==2.1.12
     # via -r requirements.in
 coverage[toml]==7.2.3
     # via
-    #   codecov
     #   pytest-cov
 cryptography==36.0.2
     # via
@@ -326,7 +324,6 @@ redis==4.5.4
 requests==2.28.2
     # via
     #   azure-core
-    #   codecov
     #   docker
     #   docker-compose
     #   google-api-core

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -112,11 +112,9 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-codecov==2.1.12
     # via -r requirements.in
 coverage[toml]==7.2.3
     # via
-    #   codecov
     #   pytest-cov
 cryptography==36.0.2
     # via
@@ -319,7 +317,6 @@ redis==4.5.4
 requests==2.28.2
     # via
     #   azure-core
-    #   codecov
     #   docker
     #   docker-compose
     #   google-api-core


### PR DESCRIPTION
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259