### PR TITLE
Update google-cloud-pubsub to major version 2.

### DIFF
--- a/google/setup.py
+++ b/google/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/testcontainers/testcontainers-python",
     install_requires=[
         "testcontainers-core",
-        "google-cloud-pubsub < 2",
+        "google-cloud-pubsub>=2",
     ],
     python_requires=">=3.7",
 )

--- a/google/tests/test_google.py
+++ b/google/tests/test_google.py
@@ -4,18 +4,19 @@ from queue import Queue
 
 
 def test_pubsub_container():
+    pubsub: PubSubContainer
     with PubSubContainer() as pubsub:
-        wait_for_logs(pubsub, r"Server started, listening on \d+", timeout=10)
+        wait_for_logs(pubsub, r"Server started, listening on \d+", timeout=60)
         # Create a new topic
         publisher = pubsub.get_publisher_client()
         topic_path = publisher.topic_path(pubsub.project, "my-topic")
-        publisher.create_topic(topic_path)
+        publisher.create_topic(name=topic_path)
 
         # Create a subscription
         subscriber = pubsub.get_subscriber_client()
         subscription_path = subscriber.subscription_path(pubsub.project,
                                                          "my-subscription")
-        subscriber.create_subscription(subscription_path, topic_path)
+        subscriber.create_subscription(name=subscription_path, topic=topic_path)
 
         # Publish a message
         publisher.publish(topic_path, b"Hello world!")

--- a/requirements/3.10.txt
+++ b/requirements/3.10.txt
@@ -112,10 +112,8 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-    # via -r requirements.in
 coverage[toml]==7.2.3
-    # via
-    #   pytest-cov
+    # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
@@ -159,7 +157,7 @@ google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
 google-auth==2.17.2
     # via google-api-core
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.16.0
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -173,11 +171,14 @@ grpc-google-iam-v1==0.12.6
 grpcio==1.53.0
     # via
     #   google-api-core
+    #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.48.2
-    # via google-api-core
+grpcio-status==1.53.0
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
 h11==0.14.0
     # via wsproto
 idna==3.4
@@ -226,7 +227,7 @@ opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
-packaging==23.0
+packaging==23.1
     # via
     #   deprecation
     #   docker
@@ -242,13 +243,16 @@ pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.3
+proto-plus==1.22.2
+    # via google-cloud-pubsub
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   proto-plus
 psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
@@ -332,7 +336,7 @@ requests-toolbelt==0.10.1
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 rsa==4.9
     # via

--- a/requirements/3.11.txt
+++ b/requirements/3.11.txt
@@ -78,18 +78,15 @@ alabaster==0.7.13
 asn1crypto==1.5.1
     # via scramp
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
-azure-core==1.26.3
+azure-core==1.26.4
     # via azure-storage-blob
 azure-storage-blob==12.15.0
     # via testcontainers-azurite
@@ -115,15 +112,14 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-    # via -r requirements.in
-coverage[toml]==7.2.1
-    # via
-    #   pytest-cov
+coverage[toml]==7.2.3
+    # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
     #   azure-storage-blob
     #   paramiko
+    #   secretstorage
 cx-oracle==8.3.0
     # via testcontainers-oracle
 deprecation==2.1.0
@@ -150,29 +146,36 @@ ecdsa==0.18.0
     # via python-jose
 entrypoints==0.3
     # via flake8
+exceptiongroup==1.1.1
+    # via trio-websocket
 flake8==3.7.9
     # via -r requirements.in
-google-api-core[grpc]==2.10.2
+google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
-google-auth==2.16.2
+google-auth==2.17.2
     # via google-api-core
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.16.0
     # via testcontainers-gcp
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+greenlet==2.0.2
+    # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.3
+grpcio==1.53.0
     # via
     #   google-api-core
+    #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.48.2
-    # via google-api-core
+grpcio-status==1.53.0
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
 h11==0.14.0
     # via wsproto
 idna==3.4
@@ -181,7 +184,7 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
@@ -191,6 +194,10 @@ isodate==0.6.1
     # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 jsonschema==3.2.0
@@ -207,23 +214,23 @@ mccabe==0.6.1
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-minio==7.1.13
+minio==7.1.14
     # via testcontainers-minio
 more-itertools==9.1.0
     # via jaraco-classes
-neo4j==5.6.0
+neo4j==5.7.0
     # via testcontainers-neo4j
 opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
-packaging==23.0
+packaging==23.1
     # via
     #   deprecation
     #   docker
     #   pytest
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pg8000==1.29.4
     # via -r requirements.in
@@ -233,14 +240,17 @@ pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.3
+proto-plus==1.22.2
+    # via google-cloud-pubsub
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-psycopg2-binary==2.9.5
+    #   proto-plus
+psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
     # via
@@ -255,7 +265,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.1.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -266,7 +276,7 @@ pymongo==4.3.3
     # via testcontainers-mongodb
 pymssql==2.2.7
     # via testcontainers-mssql
-pymysql==1.0.2
+pymysql==1.0.3
     # via testcontainers-mysql
 pynacl==1.5.0
     # via paramiko
@@ -274,7 +284,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -290,9 +300,9 @@ python-dotenv==0.21.1
     # via docker-compose
 python-jose==3.3.0
     # via python-keycloak
-python-keycloak==2.13.2
+python-keycloak==2.15.3
     # via testcontainers-keycloak
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
@@ -302,7 +312,7 @@ pyyaml==5.4.1
     # via docker-compose
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via testcontainers-redis
 requests==2.28.2
     # via
@@ -323,7 +333,7 @@ requests-toolbelt==0.10.1
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
 rsa==4.9
     # via
@@ -331,7 +341,9 @@ rsa==4.9
     #   python-jose
 scramp==1.4.4
     # via pg8000
-selenium==4.8.2
+secretstorage==3.3.3
+    # via keyring
+selenium==4.8.3
     # via testcontainers-selenium
 six==1.16.0
     # via
@@ -365,7 +377,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.5.post1
+sqlalchemy==2.0.9
     # via
     #   testcontainers-mssql
     #   testcontainers-mysql
@@ -377,7 +389,7 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.2
     # via selenium
 twine==4.0.2
     # via -r requirements.in
@@ -386,11 +398,11 @@ typing-extensions==4.5.0
     #   azure-core
     #   azure-storage-blob
     #   sqlalchemy
-tzdata==2022.7
+tzdata==2023.3
     # via pytz-deprecation-shim
-tzlocal==4.2
+tzlocal==4.3
     # via clickhouse-driver
-urllib3[socks]==1.26.14
+urllib3[socks]==1.26.15
     # via
     #   docker
     #   minio
@@ -406,7 +418,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements.in
 wrapt==1.15.0
     # via testcontainers-core

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -119,8 +119,7 @@ charset-normalizer==3.1.0
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
 coverage[toml]==7.2.3
-    # via
-    #   pytest-cov
+    # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
@@ -164,7 +163,7 @@ google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
 google-auth==2.17.2
     # via google-api-core
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.16.0
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -178,11 +177,14 @@ grpc-google-iam-v1==0.12.6
 grpcio==1.53.0
     # via
     #   google-api-core
+    #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.48.2
-    # via google-api-core
+grpcio-status==1.53.0
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
 h11==0.14.0
     # via wsproto
 idna==3.4
@@ -241,7 +243,7 @@ opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
-packaging==23.0
+packaging==23.1
     # via
     #   deprecation
     #   docker
@@ -257,13 +259,16 @@ pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.3
+proto-plus==1.22.2
+    # via google-cloud-pubsub
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   proto-plus
 psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
@@ -348,7 +353,7 @@ requests-toolbelt==0.10.1
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 rsa==4.9
     # via

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -116,10 +116,8 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-    # via -r requirements.in
 coverage[toml]==7.2.3
-    # via
-    #   pytest-cov
+    # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
@@ -163,7 +161,7 @@ google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
 google-auth==2.17.2
     # via google-api-core
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.16.0
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -177,11 +175,14 @@ grpc-google-iam-v1==0.12.6
 grpcio==1.53.0
     # via
     #   google-api-core
+    #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.48.2
-    # via google-api-core
+grpcio-status==1.53.0
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
 h11==0.14.0
     # via wsproto
 idna==3.4
@@ -233,7 +234,7 @@ opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
-packaging==23.0
+packaging==23.1
     # via
     #   deprecation
     #   docker
@@ -249,13 +250,16 @@ pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.3
+proto-plus==1.22.2
+    # via google-cloud-pubsub
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   proto-plus
 psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
@@ -340,7 +344,7 @@ requests-toolbelt==0.10.1
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 rsa==4.9
     # via

--- a/requirements/3.9.txt
+++ b/requirements/3.9.txt
@@ -112,10 +112,8 @@ charset-normalizer==3.1.0
     # via requests
 clickhouse-driver==0.2.5
     # via testcontainers-clickhouse
-    # via -r requirements.in
 coverage[toml]==7.2.3
-    # via
-    #   pytest-cov
+    # via pytest-cov
 cryptography==36.0.2
     # via
     #   -r requirements.in
@@ -159,7 +157,7 @@ google-api-core[grpc]==2.11.0
     # via google-cloud-pubsub
 google-auth==2.17.2
     # via google-api-core
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.16.0
     # via testcontainers-gcp
 googleapis-common-protos[grpc]==1.59.0
     # via
@@ -173,11 +171,14 @@ grpc-google-iam-v1==0.12.6
 grpcio==1.53.0
     # via
     #   google-api-core
+    #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.48.2
-    # via google-api-core
+grpcio-status==1.53.0
+    # via
+    #   google-api-core
+    #   google-cloud-pubsub
 h11==0.14.0
     # via wsproto
 idna==3.4
@@ -227,7 +228,7 @@ opensearch-py==2.2.0
     # via testcontainers-opensearch
 outcome==1.2.0
     # via trio
-packaging==23.0
+packaging==23.1
     # via
     #   deprecation
     #   docker
@@ -243,13 +244,16 @@ pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.3
+proto-plus==1.22.2
+    # via google-cloud-pubsub
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   proto-plus
 psycopg2-binary==2.9.6
     # via testcontainers-postgres
 pyasn1==0.4.8
@@ -333,7 +337,7 @@ requests-toolbelt==0.10.1
     #   twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.3
+rich==13.3.4
     # via twine
 rsa==4.9
     # via


### PR DESCRIPTION
☝️ 

Closes #209. Should allow #331 to pass because the outdated dependency is removed.