### PR TITLE
Remove sqlalchemy dependency from postgres connection check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Getting Started
     >>> from testcontainers.postgres import PostgresContainer
     >>> import sqlalchemy
 
-    >>> with PostgresContainer("postgres:latest") as postgres:
-    ...     psql_url = postgres.get_connection_url() # postgresql+psycopg2://test:test@localhost:61472/test
+    >>> with PostgresContainer("postgres:9.5") as postgres:
+    ...     psql_url = postgres.get_connection_url()
     ...     engine = sqlalchemy.create_engine(psql_url)
     ...     result = engine.execute("select version()")
     ...     version, = result.fetchone()
@@ -58,8 +58,8 @@ The snippet above will spin up a postgres database in a container. The :code:`ge
     >>> import asyncpg
     >>> from testcontainers.postgres import PostgresContainer
 
-    >>> with PostgresContainer("postgres:latest", driver=None) as postgres:
-    ...     psql_url = container.get_connection_url() # postgresql://test:test@localhost:61472/test
+    >>> with PostgresContainer("postgres:9.5", driver=None) as postgres:
+    ...     psql_url = container.get_connection_url()
     ...     with asyncpg.create_pool(dsn=psql_url,server_settings={"jit": "off"}) as pool:
     ...         conn = await pool.acquire()
     ...         ret = await conn.fetchval("SELECT 1")

--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,30 @@ Getting Started
     >>> from testcontainers.postgres import PostgresContainer
     >>> import sqlalchemy
 
-    >>> with PostgresContainer("postgres:9.5") as postgres:
-    ...     engine = sqlalchemy.create_engine(postgres.get_connection_url())
+    >>> with PostgresContainer("postgres:latest") as postgres:
+    ...     psql_url = postgres.get_connection_url() # postgresql+psycopg2://test:test@localhost:61472/test
+    ...     engine = sqlalchemy.create_engine(psql_url)
     ...     result = engine.execute("select version()")
     ...     version, = result.fetchone()
     >>> version
-    'PostgreSQL 9.5...'
+    'PostgreSQL ......'
 
-The snippet above will spin up a postgres database in a container. The :code:`get_connection_url()` convenience method returns a :code:`sqlalchemy` compatible url we use to connect to the database and retrieve the database version.
+The snippet above will spin up a postgres database in a container. The :code:`get_connection_url()` convenience method returns a :code:`sqlalchemy` compatible url we use to connect to the database and retrieve the database version. 
+
+.. doctest::
+
+    >>> import asyncpg
+    >>> from testcontainers.postgres import PostgresContainer
+
+    >>> with PostgresContainer("postgres:latest", driver=None) as postgres:
+    ...     psql_url = container.get_connection_url() # postgresql://test:test@localhost:61472/test
+    ...     with asyncpg.create_pool(dsn=psql_url,server_settings={"jit": "off"}) as pool:
+    ...         conn = await pool.acquire()
+    ...         ret = await conn.fetchval("SELECT 1")
+    ...         assert ret == 1
+
+This snippet does the same, however the driver is set to None, to influence the :code:`get_connection_url()` convenience method. Note, that the :code:`sqlalchemy` package is no longer a dependency to launch the Postgres container, so your project must provide support for the specified driver.
+
 
 Installation
 ------------

--- a/postgres/testcontainers/postgres/__init__.py
+++ b/postgres/testcontainers/postgres/__init__.py
@@ -17,8 +17,7 @@ from typing import Optional
 from testcontainers.core.config import MAX_TRIES, SLEEP_TIME
 from testcontainers.core.generic import DependencyFreeDbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
-from testcontainers.core.waiting_utils import (wait_container_is_ready,
-                                               wait_for_logs)
+from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 
 
 class PostgresContainer(DependencyFreeDbContainer):
@@ -44,9 +43,17 @@ class PostgresContainer(DependencyFreeDbContainer):
             >>> version
             'PostgreSQL 9.5...'
     """
-    def __init__(self, image: str = "postgres:latest", port: int = 5432,
-                 username: Optional[str] = None, password: Optional[str] = None,
-                 dbname: Optional[str] = None, driver: str | None = "psycopg2", **kwargs) -> None:
+
+    def __init__(
+        self,
+        image: str = "postgres:latest",
+        port: int = 5432,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        dbname: Optional[str] = None,
+        driver: str | None = "psycopg2",
+        **kwargs,
+    ) -> None:
         raise_for_deprecated_parameter(kwargs, "user", "username")
         super(PostgresContainer, self).__init__(image=image, **kwargs)
         self.username: str = username or os.environ.get("POSTGRES_USER", "test")
@@ -64,14 +71,19 @@ class PostgresContainer(DependencyFreeDbContainer):
 
     def get_connection_url(self, host=None) -> str:
         return super()._create_connection_url(
-            dialect=f"postgresql{self.driver}", username=self.username,
-            password=self.password, dbname=self.dbname, host=host,
+            dialect=f"postgresql{self.driver}",
+            username=self.username,
+            password=self.password,
+            dbname=self.dbname,
+            host=host,
             port=self.port,
         )
 
     @wait_container_is_ready()
     def _verify_status(self) -> None:
-        wait_for_logs(self, ".*database system is ready to accept connections.*", MAX_TRIES, SLEEP_TIME)
+        wait_for_logs(
+            self, ".*database system is ready to accept connections.*", MAX_TRIES, SLEEP_TIME
+        )
 
         count = 0
         while count < MAX_TRIES:

--- a/postgres/tests/test_postgres.py
+++ b/postgres/tests/test_postgres.py
@@ -8,8 +8,9 @@ def test_docker_run_postgres():
     for version in supported_versions:
         postgres_container = PostgresContainer(f"postgres:{version}")
         with postgres_container as postgres:
-            status, msg = postgres.exec(f"pg_isready -hlocalhost -p{postgres.port} -U{postgres.username}")
+            status, msg = postgres.exec(
+                f"pg_isready -hlocalhost -p{postgres.port} -U{postgres.username}"
+            )
 
             assert msg.decode("utf-8").endswith("accepting connections\n")
             assert status == 0
-


### PR DESCRIPTION
I decided to include both the log check & the `pg_isready` check, as it seems they both need to be successful in order to enure the database is running.  

I don't think the `driver` parameter  belongs in `Postgres.__init__` method, as it's only used when building the connection string, but I didn't want to introduce any breaking changes.

Also, I am pretty new to python and was having trouble adding my fork of the project as a package to an external test project. It would be nice if there were some guidance on that in the README.  I tried following the instructions in both the `poetry` and `pip` documentation, but couldn't install from github as there is neither `setup.py`  nor `pyproject.toml` in the root directory.



