### PR TITLE
Raise error on unknown marker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ${DISTRIBUTIONS} : %/dist : %/setup.py
 # Targets to run the test suite for each package.
 tests : ${TESTS}
 ${TESTS} : %/tests :
-	pytest -svx --cov-report=term-missing --cov=testcontainers.$* --tb=short $*/tests
+	pytest -svx --cov-report=term-missing --cov=testcontainers.$* --tb=short --strict-markers $*/tests
 
 # Targets to lint the code.
 lint : ${LINT}


### PR DESCRIPTION
Avoids tests accidentally passing as in #320 because `pytest-asycnio` is missing.