### PR TITLE
feat: Add proper support for Keycloak

### DIFF
--- a/keycloak/testcontainers/keycloak/__init__.py
+++ b/keycloak/testcontainers/keycloak/__init__.py
@@ -11,44 +11,75 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import os
-import requests
-
-from keycloak import KeycloakAdmin
-
-from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_container_is_ready
 from typing import Optional
+
+import requests
+from keycloak import KeycloakAdmin
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 
 
 class KeycloakContainer(DockerContainer):
     """
-    Keycloak container.
+        Keycloak container.
 
-    Example:
+        Example:
 
-        .. doctest::
+            .. doctest::
 
-            >>> from testcontainers.keycloak import KeycloakContainer
+                >>> from testcontainers.keycloak import KeycloakContainer
 
-            >>> with KeycloakContainer() as kc:
-            ...    keycloak = kc.get_client()
+                >>> with KeycloakContainer() as kc:
+                ...    keycloak = kc.get_client()
     """
-    def __init__(self, image="jboss/keycloak:latest", username: Optional[str] = None,
-                 password: Optional[str] = None, port: int = 8080) -> None:
+    def __init__(
+            self,
+            image="quay.io/keycloak/keycloak:latest",
+            username: Optional[str] = None,
+            password: Optional[str] = None,
+            port: int = 8080
+    ) -> None:
         super(KeycloakContainer, self).__init__(image=image)
-        self.username = username or os.environ.get("KEYCLOAK_USER", "test")
-        self.password = password or os.environ.get("KEYCLOAK_PASSWORD", "test")
+        self.username = username or os.getenv("KEYCLOAK_ADMIN", "test")
+        self.password = password or os.getenv("KEYCLOAK_ADMIN_PASSWORD", "test")
         self.port = port
         self.with_exposed_ports(self.port)
 
+    def _get_image_tag(self) -> str:
+        return self.image.split(":")[1]
+
+    def _uses_legacy_architecture(self) -> bool:
+        tag = self._get_image_tag()
+
+        try:
+            major_version_number = int(tag.split(".")[0])
+        except ValueError:
+            major_version_number = 2023
+
+        return major_version_number <= 16 or "legacy" in tag.lower()
+
     def _configure(self) -> None:
+        # There's a bit of confusion as to which version / architecture uses which
+        # Because of this we're setting the credentials both ways
+        self.with_env("KEYCLOAK_ADMIN", self.username)
+        self.with_env("KEYCLOAK_ADMIN_PASSWORD", self.password)
         self.with_env("KEYCLOAK_USER", self.username)
         self.with_env("KEYCLOAK_PASSWORD", self.password)
+
+        self.with_env("KC_HEALTH_ENABLED", "true")
+        self.with_env("KC_METRICS_ENABLED", "true")
+
+        if not self._uses_legacy_architecture():
+            self.with_command("start-dev")
 
     def get_url(self) -> str:
         host = self.get_container_host_ip()
         port = self.get_exposed_port(self.port)
         return f"http://{host}:{port}"
+
+    def get_base_api_url(self) -> str:
+        base_url = self.get_url()
+        return f"{base_url}/auth" if self._uses_legacy_architecture() else base_url
 
     @wait_container_is_ready(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout)
     def _connect(self) -> None:
@@ -58,20 +89,19 @@ class KeycloakContainer(DockerContainer):
 
     def start(self) -> "KeycloakContainer":
         self._configure()
-        super().start()
-        self._connect()
+        container = super().start()
+
+        if self._uses_legacy_architecture():
+            self._connect()
+        else:
+            wait_for_logs(container, 'Listening on:')
+
         return self
 
     def get_client(self, **kwargs) -> KeycloakAdmin:
-        default_kwargs = dict(
-            server_url=f"{self.get_url()}/auth/",
+        return KeycloakAdmin(
+            server_url=f"{self.get_base_api_url()}/",
             username=self.username,
             password=self.password,
-            realm_name="master",
-            verify=True,
+            verify=True
         )
-        kwargs = {
-            **default_kwargs,
-            **kwargs
-        }
-        return KeycloakAdmin(**kwargs)

--- a/keycloak/tests/test_keycloak.py
+++ b/keycloak/tests/test_keycloak.py
@@ -3,7 +3,10 @@ import pytest
 from testcontainers.keycloak import KeycloakContainer
 
 
-@pytest.mark.parametrize("version", ["16.1.1"])
+@pytest.mark.parametrize("version", ["nightly", "latest", "legacy", "21.1.2", "21.0.2", "20.0.5", "19.0.3",
+                                     "19.0.3-legacy", "18.0.2", "18.0.2-legacy", "17.0.1", "17.0.1-legacy", "16.1.1",
+                                     "15.1.1", "14.0.0", "13.0.1", "12.0.4", "11.0.2", "10.0.2", "9.0.3", "8.0.2",
+                                     "7.0.1", "6.0.1", "5.0.0"])
 def test_docker_run_keycloak(version: str):
-    with KeycloakContainer(f'jboss/keycloak:{version}') as kc:
-        kc.get_client().users_count()
+    with KeycloakContainer(f"quay.io/keycloak/keycloak:{version}") as kc:
+        assert kc.get_client().users_count() > 0


### PR DESCRIPTION
The testcontainers library is giving support for a deprecated image of Keycloak.

This PR aims to give support to the new image of Keycloak, making sure it works independently of the tag used.

This has proved to be more difficult than it should've because of many reasons:

1. The lack of proper docs from Keycloak
2. Lots of differences between legacy and non-legacy Keycloak instances (with no documentation to explain better)
3. API differences between versions / architectures

The code works 100% fine according to my tests and the tests added. I haven't tested with the legacy image tbh, but I have a hunch it might just work, except for version 17 and up.