### PR TITLE
fix: pin PyYAML to 5.3.1 for Python versions >= 3.10

### DIFF
--- a/requirements/macos-latest-3.10.txt
+++ b/requirements/macos-latest-3.10.txt
@@ -317,7 +317,7 @@ pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via docker-compose
 readme-renderer==37.3
     # via twine

--- a/requirements/ubuntu-latest-3.10.txt
+++ b/requirements/ubuntu-latest-3.10.txt
@@ -322,7 +322,7 @@ pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via docker-compose
 readme-renderer==37.3
     # via twine

--- a/requirements/ubuntu-latest-3.11.txt
+++ b/requirements/ubuntu-latest-3.11.txt
@@ -317,7 +317,7 @@ pytz==2023.3
     # via
     #   clickhouse-driver
     #   neo4j
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via docker-compose
 readme-renderer==37.3
     # via twine

--- a/requirements/windows-latest-3.10.txt
+++ b/requirements/windows-latest-3.10.txt
@@ -327,7 +327,7 @@ pywin32==306
     # via docker
 pywin32-ctypes==0.2.0
     # via keyring
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via docker-compose
 readme-renderer==37.3
     # via twine


### PR DESCRIPTION
PR builds are currently failing with PyYAML 5.4.1 due to a Cython incompatibility.

E.g. https://github.com/testcontainers/testcontainers-python/actions/runs/5570814818/job/15393831115?pr=371

Upgrading PyYAML to 6.X is not an option because docker-compose V1 is incompatible and won't receive any updates due to EOL (see https://github.com/docker/compose/issues/9114).

This should be the temporary fix until #358  is implemented.

References:
- https://github.com/yaml/pyyaml/issues/601
- https://github.com/cython/cython/issues/4568