### PR TITLE
fix(core): add TESTCONTAINERS_HOST_OVERRIDE as alternative to TC_HOST

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -166,6 +166,8 @@ class DockerClient:
         # https://github.com/testcontainers/testcontainers-go/blob/dd76d1e39c654433a3d80429690d07abcec04424/docker.go#L644
         # if os env TC_HOST is set, use it
         host = os.environ.get("TC_HOST")
+        if not host:
+            host = os.environ.get("TESTCONTAINERS_HOST_OVERRIDE")
         if host:
             return host
         try:

--- a/index.rst
+++ b/index.rst
@@ -80,6 +80,8 @@ This snippet does the same, however using a specific version and the driver is s
 
 Note, that the :code:`sqlalchemy` and :code:`psycopg` packages are no longer a dependency of :code:`testcontainers[postgres]` and not needed to launch the Postgres container. Your project therefore needs to declare a dependency on the used driver and db access methods you use in your code.
 
+By default, Testcontainers will search for the container via the gateway IP. You can manually specify your own IP with the environment variable `TESTCONTAINERS_HOST_OVERRIDE`.
+
 
 Installation
 ------------


### PR DESCRIPTION
Resolves #383 

This PR aims to unify the configuration for the Testcontainer Hostvariable as it is in [Java](https://java.testcontainers.org/features/configuration/#customizing-docker-host-detection) and [Dotnet](https://dotnet.testcontainers.org/custom_configuration/) (and potentially others).