### PR TITLE
Add support for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "20.10",
+			"dockerDashComposeVersion": "v2"
+		}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install --user -r requirements/ubuntu-latest-3.11.txt",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
+	}
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"version": "20.10",
+			"version": "latest",
 			"dockerDashComposeVersion": "v2"
 		}
 	},
@@ -18,7 +18,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r requirements/ubuntu-latest-3.11.txt",
+	"postCreateCommand": "pip install --user -r requirements/ubuntu-latest-3.11.txt",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ venv
 .testrepository/
 
 # vscode:
-.devcontainer/
 .vscode/
 
 .DS_Store

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ testcontainers-python
    :target: https://pypi.python.org/pypi/testcontainers
 .. image:: https://readthedocs.org/projects/testcontainers-python/badge/?version=latest
    :target: http://testcontainers-python.readthedocs.io/en/latest/?badge=latest
+.. image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/testcontainers/testcontainers-python
 
 testcontainers-python facilitates the use of Docker containers for functional and integration testing. The collection of packages currently supports the following features.
 


### PR DESCRIPTION
## What does this PR do?

Adds pre-configured support for GitHub Codespaces and local development using dev containers.

## Why is it important?

Makes maintenance, contributions and reviewing PRs easier, since it does not required developers to maintain a permanent local development environment (which is a bit more challenging, given the current approach of managing dependencies).