### PR TITLE
feat: support greptimedb container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         - core
         - elasticsearch
         - google
+        - greptimedb
         - kafka
         - keycloak
         - localstack

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ testcontainers-python facilitates the use of Docker containers for functional an
     clickhouse/README
     elasticsearch/README
     google/README
+    greptimedb/README
     kafka/README
     keycloak/README
     localstack/README

--- a/greptimedb/README.rst
+++ b/greptimedb/README.rst
@@ -1,0 +1,1 @@
+.. autoclass:: testcontainers.greptimedb.GreptimeDBContainer

--- a/greptimedb/setup.py
+++ b/greptimedb/setup.py
@@ -1,0 +1,14 @@
+from setuptools import find_namespace_packages, setup
+
+description = "GreptimeDB component of testcontainers-python."
+
+setup(
+    name="testcontainers-greptimedb",
+    version="0.0.1",
+    packages=find_namespace_packages(),
+    description=description,
+    long_description=description,
+    url="https://github.com/testcontainers/testcontainers-python",
+    install_requires=["testcontainers-core", "sqlalchemy", "pymysql[rsa]"],
+    python_requires=">=3.7",
+)

--- a/greptimedb/testcontainers/greptimedb/__init__.py
+++ b/greptimedb/testcontainers/greptimedb/__init__.py
@@ -42,7 +42,7 @@ class GreptimeDBContainer(DbContainer):
 
     def __init__(
         self,
-        image: str = "greptimedb:latest",
+        image: str = "greptime/greptimedb:latest",
         username: Optional[str] = None,
         password: Optional[str] = None,
         dbname: Optional[str] = None,
@@ -68,6 +68,14 @@ class GreptimeDBContainer(DbContainer):
             self.grpc_port,
             self.mysql_port,
             self.pg_port,
+        )
+
+        self.with_command(
+            "standalone start"
+            + f" --http-addr=0.0.0.0:{self.http_port}"
+            + f" --rpc-addr=0.0.0.0:{self.grpc_port}"
+            + f" --mysql-addr=0.0.0.0:{self.mysql_port}"
+            + f" --postgres-addr=0.0.0.0:{self.pg_port}"
         )
 
     def _configure(self) -> None:

--- a/greptimedb/testcontainers/greptimedb/__init__.py
+++ b/greptimedb/testcontainers/greptimedb/__init__.py
@@ -1,0 +1,85 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from os import environ
+from typing import Optional
+
+from testcontainers.core.generic import DbContainer
+from testcontainers.core.utils import raise_for_deprecated_parameter
+
+
+class GreptimeDBContainer(DbContainer):
+    """
+    GreptimeDB database container.
+
+    Example:
+
+        The example will spin up a GreptimeDB database to which you can connect with the credentials
+        passed in the constructor. Alternatively, you may use the :code:`get_connection_url()`
+        method which returns a sqlalchemy-compatible url in format
+        :code:`dialect+driver://username:password@host:port/database`.
+
+        .. doctest::
+
+            >>> import sqlalchemy
+            >>> from testcontainers.greptimedb import GreptimeDBContainer
+
+            >>> with GreptimeDBContainer('greptime/greptimedb:v0.4.3') as greptimedb:
+            ...     engine = sqlalchemy.create_engine(greptimedb.get_connection_url())
+            ...     with engine.begin() as connection:
+            ...         result = connection.execute(sqlalchemy.text("select version()"))
+            ...         version, = result.fetchone()
+    """
+
+    def __init__(
+        self,
+        image: str = "greptimedb:latest",
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        dbname: Optional[str] = None,
+        http_port: int = 4000,
+        grpc_port: int = 4001,
+        mysql_port: int = 4002,
+        pg_port: int = 4003,
+        **kwargs,
+    ) -> None:
+        super(GreptimeDBContainer, self).__init__(image, **kwargs)
+
+        self.http_port = http_port
+        self.grpc_port = grpc_port
+        self.mysql_port = mysql_port
+        self.pg_port = pg_port
+
+        self.username = username or environ.get("GREPTIMEDB_USER", "test")
+        self.password = password or environ.get("GREPTIMEDB_PASSWORD", "test")
+        self.dbname = dbname or environ.get("GREPTIMEDB_DATABASE", "public")
+
+        self.with_exposed_ports(
+            self.http_port,
+            self.grpc_port,
+            self.mysql_port,
+            self.pg_port,
+        )
+
+    def _configure(self) -> None:
+        self.with_env("GREPTIMEDB_USER", self.username)
+        self.with_env("GREPTIMEDB_PASSWORD", self.password)
+        self.with_env("GREPTIMEDB_DATABASE", self.dbname)
+
+    def get_connection_url(self) -> str:
+        return super()._create_connection_url(
+            dialect="mysql+pymysql",
+            username=self.username,
+            password=self.password,
+            dbname=self.dbname,
+            port=self.mysql_port,
+        )

--- a/greptimedb/tests/test_greptimedb.py
+++ b/greptimedb/tests/test_greptimedb.py
@@ -12,4 +12,4 @@ def test_docker_run_greptimedb():
         with engine.begin() as connection:
             result = connection.execute(sqlalchemy.text("select version()"))
             for row in result:
-                assert row[0].startswith("v0.4.3")
+                assert row[0].endswith("greptime")

--- a/greptimedb/tests/test_greptimedb.py
+++ b/greptimedb/tests/test_greptimedb.py
@@ -1,0 +1,15 @@
+import re
+from unittest import mock
+
+import sqlalchemy
+from testcontainers.greptimedb import GreptimeDBContainer
+
+
+def test_docker_run_greptimedb():
+    config = GreptimeDBContainer("greptime/greptimedb:v0.4.3")
+    with config as greptimedb:
+        engine = sqlalchemy.create_engine(greptimedb.get_connection_url())
+        with engine.begin() as connection:
+            result = connection.execute(sqlalchemy.text("select version()"))
+            for row in result:
+                assert row[0].startswith("v0.4.3")


### PR DESCRIPTION
Add GreptimeDB into testcontainer.

## what GreptimedDB is

GreptimeDB is an open-source time-series database with a special focus on scalability, analytical capabilities and efficiency. It's designed to work on infrastructure of the cloud era, and users benefit from its elasticity and commodity storage.


It is written in Rust, and compatible with MySQL, PostgresQL, and PromQL

## Docker Hub

https://hub.docker.com/r/greptime/greptimedb

## GitHub Repository

https://github.com/greptimeteam/greptimedb

## Homepage

https://greptime.com/