### PR TITLE
Release new version of testcontainers-gcp

### DIFF
--- a/google/setup.py
+++ b/google/setup.py
@@ -4,7 +4,7 @@ description = "Google Cloud Platform component of testcontainers-python."
 
 setup(
     name="testcontainers-gcp",
-    version="0.0.1rc1",
+    version="0.0.2rc1",
     packages=find_namespace_packages(),
     description=description,
     long_description=description,


### PR DESCRIPTION
For contest, see https://github.com/testcontainers/testcontainers-python/issues/403

Current version on PyPI (0.0.1rc1) is not in sync with branch `main`. This PR will bump the version and as such that version will hold the changes from this commit: https://github.com/testcontainers/testcontainers-python/commit/934c8d884ff513d3ede3b7faab2860f110799585

Not sure what we need to do to actually _publish_ this to PyPI?