### PR TITLE
fix: changed files breaks on main

### DIFF
--- a/.github/workflows/ci-community.yml
+++ b/.github/workflows/ci-community.yml
@@ -45,6 +45,8 @@ jobs:
           - k3s
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout contents
+        uses: actions/checkout@v4
       - name: Get changed files
         id: changes-for-module
         uses: tj-actions/changed-files@v42
@@ -59,8 +61,6 @@ jobs:
           gh run watch ${{ github.run_id }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout contents
-        uses: actions/checkout@v4
       - name: Setup Poetry
         run: pipx install poetry
       - name: Setup python ${{ matrix.python-version }}


### PR DESCRIPTION
# change

Fixes an issue with the usage of https://github.com/tj-actions/changed-files.
Without a checkout, it breaks on `main`. This re-introduces that push to main.