### PR TITLE
fix(release): prove that the release process updates the version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "testcontainers"
-version = "4.0.0"  # auto-incremented by release-please
+version = "4.0.0rc2"  # auto-incremented by release-please
 description = "Python library for throwaway instances of anything that can run in a Docker container"
 authors = ["Sergey Pirogov <automationremarks@gmail.com>"]
 maintainers = [


### PR DESCRIPTION
# change

Set the version to the latest actual release candidate done by @alexanderankin.

# Context

In the first release-please PR #433 , we're not setting the version on the `pyproject.toml`, suspecting that it still works, but want to prove there are no issues with the automation.

The easiest proof of this is to set the value in the file to the actual release candidate. `release-please` in the future will be able to do release candidates by running `release-please` from the command line (documentation to be made on this)