### PR TITLE
fix: failing tests for elasticsearch on machines with ARM CPU

### DIFF
--- a/modules/elasticsearch/tests/test_elasticsearch.py
+++ b/modules/elasticsearch/tests/test_elasticsearch.py
@@ -6,8 +6,8 @@ import pytest
 from testcontainers.elasticsearch import ElasticSearchContainer
 
 
-# The versions below were the current supported versions at time of writing (2022-08-11)
-@pytest.mark.parametrize("version", ["6.8.23", "7.17.5", "8.3.3"])
+# The versions below should reflect the latest stable releases
+@pytest.mark.parametrize("version", ["7.17.18", "8.12.2"])
 def test_docker_run_elasticsearch(version):
     with ElasticSearchContainer(f"elasticsearch:{version}", mem_limit="3G") as es:
         resp = urllib.request.urlopen(es.get_url())


### PR DESCRIPTION
- updated the image versions used for tests with the latest supported tags: https://hub.docker.com/_/elasticsearch
- fixes https://github.com/testcontainers/testcontainers-python/issues/452

![Screenshot 2024-03-09 at 09 49 53](https://github.com/testcontainers/testcontainers-python/assets/13573675/84384190-3cc2-47c3-b795-a86efc062e3c)
