### PR TITLE
fix(mongodb): waiting for container to start (it was not waiting at all before?)

### DIFF
--- a/modules/mongodb/testcontainers/mongodb/__init__.py
+++ b/modules/mongodb/testcontainers/mongodb/__init__.py
@@ -17,7 +17,7 @@ from pymongo import MongoClient
 
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
-from testcontainers.core.waiting_utils import wait_container_is_ready
+from testcontainers.core.waiting_utils import wait_for_logs
 
 
 class MongoDbContainer(DbContainer):
@@ -81,9 +81,8 @@ class MongoDbContainer(DbContainer):
             port=self.port,
         )
 
-    @wait_container_is_ready()
-    def _connect(self) -> MongoClient:
-        return MongoClient(self.get_connection_url())
+    def _connect(self) -> None:
+        wait_for_logs(self, "Waiting for connections")
 
     def get_connection_client(self) -> MongoClient:
-        return self._connect()
+        return MongoClient(self.get_connection_url())


### PR DESCRIPTION
we were using this code to test if it was online or not:`MongoClient(self.get_connection_url())`, but that doesn't actually perform any connection, instead you have to do something like:

```python
    @wait_container_is_ready()
    def _connect(self):
        client = self.get_connection_client()
        # will raise pymongo.errors.ServerSelectionTimeoutError if no connection is established
        client.admin.command('ismaster')
```

thanks to @smparekh for pointing this out, in his PR:

https://github.com/testcontainers/testcontainers-python/pull/80/files#diff-cf09f76f44db0af04c58ddb456ccae39f7e29ce1d9208acd5f514c0a7dccb646R78

this PR implements the workaround described in the PR:

```python
@pytest.fixture(scope="session")
def test_client():
    # init mongo
    mongo_container = MongoDbContainer("mongo:4").start()
    wait_for_logs(mongo_container, 'waiting for connections on port 27017')
    ...