### PR TITLE
fix(configuration): strip whitespaces when reading .testcontainers.properties

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -143,7 +143,7 @@ def read_tc_properties() -> dict[str, str]:
         tuples = []
         with open(file) as contents:
             tuples = [line.split("=") for line in contents.readlines() if "=" in line]
-            settings = {**settings, **{item[0]: item[1] for item in tuples}}
+            settings = {**settings, **{item[0].strip(): item[1].strip() for item in tuples}}
     return settings
 
 


### PR DESCRIPTION
## What does this PR do?

Strip whitespaces from key and value after reading `~/.testcontainers.properties`. The way TCD writes this file, the `=` will be surrounded by whitespaces, e.g.:

```
kiview@kay ~ % cat .testcontainers.properties
tc.host = tcp://127.0.0.1:59499
testcontainers.reuse.enable = true
```

## Why is it important?

Adds Plug&Play support for Testcontainers Desktop and Testcontainers Cloud.

## How to test this PR

Run any kind of tests that involve creating and starting containers, while Testcontainers Desktop is running. Testcontainers Desktop should be used and hence started containers can be seen in the Testcontainers Cloud dashboard.