### PR TITLE
fix(arangodb): tests to pass on ARM CPUs - change default image to 3.11.x where ARM image is published

### DIFF
--- a/modules/arangodb/testcontainers/arangodb/__init__.py
+++ b/modules/arangodb/testcontainers/arangodb/__init__.py
@@ -26,7 +26,7 @@ class ArangoDbContainer(DbContainer):
             >>> from testcontainers.arangodb import ArangoDbContainer
             >>> from arango import ArangoClient
 
-            >>> with ArangoDbContainer("arangodb:3.9.1") as arango:
+            >>> with ArangoDbContainer("arangodb:3.11.8") as arango:
             ...    client = ArangoClient(hosts=arango.get_connection_url())
             ...
             ...    # Connect


### PR DESCRIPTION
- updated arangodb image version which now supports ARM CPUs
- skipping test for legacy version on ARM CPU

fixes https://github.com/testcontainers/testcontainers-python/issues/449

![Screenshot 2024-03-15 at 11 43 35](https://github.com/testcontainers/testcontainers-python/assets/13573675/9fe5edfc-9a83-44d2-beb5-9c917d41438c)
