### PR TITLE
fix(keycloak): tests on aarch64, use image from [jboss -> quay], change supported version [16+ -> 18+]

### DIFF
--- a/modules/keycloak/tests/test_keycloak.py
+++ b/modules/keycloak/tests/test_keycloak.py
@@ -1,9 +1,6 @@
-import pytest
-
 from testcontainers.keycloak import KeycloakContainer
 
 
-@pytest.mark.parametrize("version", ["16.1.1"])
-def test_docker_run_keycloak(version: str):
-    with KeycloakContainer(f"jboss/keycloak:{version}") as kc:
-        kc.get_client().users_count()
+def test_docker_run_keycloak():
+    with KeycloakContainer("quay.io/keycloak/keycloak:24.0.1") as keycloak_admin:
+        keycloak_admin.get_client().users_count()


### PR DESCRIPTION
- jboss/keycloak is discontinued, adapting the official Docker image: https://quay.io/repository/keycloak/keycloak
- switched to the latest image version with ARM support

fixes https://github.com/testcontainers/testcontainers-python/issues/451
fixes https://github.com/testcontainers/testcontainers-python/issues/483

![Screenshot 2024-03-15 at 12 42 29](https://github.com/testcontainers/testcontainers-python/assets/13573675/f82b9372-a94e-45c8-a47b-7ddb4c1c6a57)
