### PR TITLE
chore(release): completely remove bootstrap-sha as we're bootstrapped

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,5 @@
 {
     "release-type": "python",
-    "bootstrap-sha": "dcb4f6842cbfe6e880a77b0d4aabb3f396c6dc19",
     "packages": {
         ".": {
             "package-name": "testcontainers"


### PR DESCRIPTION
# change

remove the bootstrap sha from `release-please` since we're now bootstrapped - this will enable the tool to check for the latest release PR instead of looking at the SHA