### PR TITLE
fix(keycloak): container should use dedicated API endpoints to determine container readiness

### DIFF
--- a/modules/keycloak/tests/test_keycloak.py
+++ b/modules/keycloak/tests/test_keycloak.py
@@ -1,6 +1,8 @@
+import pytest
 from testcontainers.keycloak import KeycloakContainer
 
 
-def test_docker_run_keycloak():
-    with KeycloakContainer("quay.io/keycloak/keycloak:24.0.1") as keycloak_admin:
+@pytest.mark.parametrize("image_version", ["24.0.1", "18.0"])
+def test_docker_run_keycloak(image_version: str):
+    with KeycloakContainer(f"quay.io/keycloak/keycloak:{image_version}") as keycloak_admin:
         keycloak_admin.get_client().users_count()


### PR DESCRIPTION
As decided to support v18.0 image or newer, we should use these dedicated API endpoints to determine container readiness. These endpoints became introduced with v18.0.
