### PR TITLE
fix(docs): update the non-existent main.yml badge

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,6 +1,8 @@
 testcontainers-python
 =====================
 
+.. image:: https://github.com/testcontainers/testcontainers-python/actions/workflows/ci-core.yml/badge.svg
+   :target: https://github.com/testcontainers/testcontainers-python/actions/workflows/ci-core.yml
 .. image:: https://img.shields.io/pypi/v/testcontainers.svg
    :target: https://pypi.python.org/pypi/testcontainers
 .. image:: https://readthedocs.org/projects/testcontainers-python/badge/?version=latest

--- a/index.rst
+++ b/index.rst
@@ -1,8 +1,6 @@
 testcontainers-python
 =====================
 
-.. image:: https://github.com/testcontainers/testcontainers-python/workflows/testcontainers-python/badge.svg
-   :target: https://github.com/testcontainers/testcontainers-python/actions/workflows/main.yml
 .. image:: https://img.shields.io/pypi/v/testcontainers.svg
    :target: https://pypi.python.org/pypi/testcontainers
 .. image:: https://readthedocs.org/projects/testcontainers-python/badge/?version=latest


### PR DESCRIPTION
The .github/workflows/main.yml has already been removed. This caused the badge on the tutorial page not to be displayed, so it has been removed from index.rst.

![image](https://github.com/testcontainers/testcontainers-python/assets/30658134/f6df32ce-aa93-43f5-becc-2dd8ec0322d7)

# Target Page
https://testcontainers-python.readthedocs.io/en/latest/README.html