### PR TITLE
fix: move readthedocs link from "testcontainers-python" to "testcontainers" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 For more information, see [the docs][readthedocs].
 
-[readthedocs]: https://testcontainers-python.readthedocs.io/en/latest/
+[readthedocs]: https://testcontainers.readthedocs.io/en/latest/
 
 ## Getting Started
 


### PR DESCRIPTION
We need to change here too:

![Screenshot 2024-03-24 at 22 23 12](https://github.com/testcontainers/testcontainers-python/assets/16025055/7d3da7dc-ef22-4509-ad43-1d1c53977bdd)

Follow the new link: https://testcontainers.readthedocs.io/en/latest/

Thank you @alexanderankin 