### PR TITLE
feat(client): Add custom User-Agent in Docker client as `tc-python/<version>`

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -11,6 +11,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import functools as ft
+import importlib.metadata
 import ipaddress
 import os
 import urllib
@@ -44,6 +45,7 @@ class DockerClient:
         else:
             self.client = docker.from_env(**kwargs)
         self.client.api.headers["x-tc-sid"] = SESSION_ID
+        self.client.api.headers["User-Agent"] = "tc-python/" + importlib.metadata.version("testcontainers")
 
     @ft.wraps(ContainerCollection.run)
     def run(


### PR DESCRIPTION
Set User-Agent in format `tc-python/<version>`, `version` value is coming from `pyproject.toml`.

The `User-Agent` header will allow to identify Testcontainers language implementation and the specific version. Also, track the usage of the library.
