### PR TITLE
fix(core): Improving typing for common container usage scenarios

### DIFF
--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -54,29 +54,29 @@ class DockerContainer:
         self._name = None
         self._kwargs = kwargs
 
-    def with_env(self, key: str, value: str) -> "DockerContainer":
+    def with_env(self, key: str, value: str) -> Self:
         self.env[key] = value
         return self
 
-    def with_bind_ports(self, container: int, host: Optional[int] = None) -> "DockerContainer":
+    def with_bind_ports(self, container: int, host: Optional[int] = None) -> Self:
         self.ports[container] = host
         return self
 
-    def with_exposed_ports(self, *ports: int) -> "DockerContainer":
+    def with_exposed_ports(self, *ports: int) -> Self:
         for port in ports:
             self.ports[port] = None
         return self
 
-    def with_kwargs(self, **kwargs) -> "DockerContainer":
+    def with_kwargs(self, **kwargs) -> Self:
         self._kwargs = kwargs
         return self
 
-    def maybe_emulate_amd64(self) -> "DockerContainer":
+    def maybe_emulate_amd64(self) -> Self:
         if is_arm():
             return self.with_kwargs(platform="linux/amd64")
         return self
 
-    def start(self):
+    def start(self) -> Self:
         if not RYUK_DISABLED and self.image != RYUK_IMAGE:
             logger.debug("Creating Ryuk container")
             Reaper.get_instance()
@@ -140,15 +140,15 @@ class DockerContainer:
                 return port
         return mapped_port
 
-    def with_command(self, command: str) -> "DockerContainer":
+    def with_command(self, command: str) -> Self:
         self._command = command
         return self
 
-    def with_name(self, name: str) -> "DockerContainer":
+    def with_name(self, name: str) -> Self:
         self._name = name
         return self
 
-    def with_volume_mapping(self, host: str, container: str, mode: str = "ro") -> "DockerContainer":
+    def with_volume_mapping(self, host: str, container: str, mode: str = "ro") -> Self:
         mapping = {"bind": container, "mode": mode}
         self.volumes[host] = mapping
         return self

--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -4,6 +4,7 @@ from socket import socket
 from typing import TYPE_CHECKING, Optional
 
 import docker.errors
+from typing_extensions import Self
 
 from testcontainers.core.config import (
     RYUK_DISABLED,
@@ -95,10 +96,11 @@ class DockerContainer:
         return self
 
     def stop(self, force=True, delete_volume=True) -> None:
-        self._container.remove(force=force, v=delete_volume)
+        if self._container:
+            self._container.remove(force=force, v=delete_volume)
         self.get_docker_client().client.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:


### PR DESCRIPTION
Improves type hints for type checking in a common use cases:

```python
with MySqlContainer("mysql:8").with_env("some", "value") as mysql:
    url = mysql.get_connection_url()  # get_connection_url would previously be an unknown member here
```
And, also improved type hinting for the custom `DockerClient`'s `run` command, where the linter no longer reports an error due to missing parameter types:
```python
DockerClient.run("nginx")  # Previously this would report "Argument missing for parameter "image"
```
