### PR TITLE
refactor: make config monkeypatchable

### DIFF
--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -6,13 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import docker.errors
 from typing_extensions import Self
 
-from testcontainers.core.config import (
-    RYUK_DISABLED,
-    RYUK_DOCKER_SOCKET,
-    RYUK_IMAGE,
-    RYUK_PRIVILEGED,
-    RYUK_RECONNECTION_TIMEOUT,
-)
+from testcontainers.core import config
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.exceptions import ContainerStartException
 from testcontainers.core.labels import LABEL_SESSION_ID, SESSION_ID
@@ -77,7 +71,7 @@ class DockerContainer:
         return self
 
     def start(self) -> Self:
-        if not RYUK_DISABLED and self.image != RYUK_IMAGE:
+        if not config.RYUK_DISABLED and self.image != config.RYUK_IMAGE:
             logger.debug("Creating Ryuk container")
             Reaper.get_instance()
         logger.info("Pulling image %s", self.image)
@@ -201,12 +195,12 @@ class Reaper:
         logger.debug(f"Creating new Reaper for session: {SESSION_ID}")
 
         Reaper._container = (
-            DockerContainer(RYUK_IMAGE)
+            DockerContainer(config.RYUK_IMAGE)
             .with_name(f"testcontainers-ryuk-{SESSION_ID}")
             .with_exposed_ports(8080)
-            .with_volume_mapping(RYUK_DOCKER_SOCKET, "/var/run/docker.sock", "rw")
-            .with_kwargs(privileged=RYUK_PRIVILEGED, auto_remove=True)
-            .with_env("RYUK_RECONNECTION_TIMEOUT", RYUK_RECONNECTION_TIMEOUT)
+            .with_volume_mapping(config.RYUK_DOCKER_SOCKET, "/var/run/docker.sock", "rw")
+            .with_kwargs(privileged=config.RYUK_PRIVILEGED, auto_remove=True)
+            .with_env("RYUK_RECONNECTION_TIMEOUT", config.RYUK_RECONNECTION_TIMEOUT)
             .start()
         )
         wait_for_logs(Reaper._container, r".* Started!")

--- a/core/testcontainers/core/labels.py
+++ b/core/testcontainers/core/labels.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import uuid4
 
-from testcontainers.core.config import RYUK_IMAGE
+from testcontainers.core import config
 
 SESSION_ID: str = str(uuid4())
 LABEL_SESSION_ID = "org.testcontainers.session-id"
@@ -13,7 +13,7 @@ def create_labels(image: str, labels: Optional[dict[str, str]]) -> dict[str, str
         labels = {}
     labels[LABEL_LANG] = "python"
 
-    if image == RYUK_IMAGE:
+    if image == config.RYUK_IMAGE:
         return labels
 
     labels[LABEL_SESSION_ID] = SESSION_ID

--- a/core/tests/test_ryuk.py
+++ b/core/tests/test_ryuk.py
@@ -5,7 +5,7 @@ from pytest import MonkeyPatch
 from docker import DockerClient
 from docker.errors import NotFound
 
-from testcontainers.core import container as container_module
+from testcontainers.core import config
 from testcontainers.core.container import Reaper
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -13,7 +13,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 def test_wait_for_reaper(monkeypatch: MonkeyPatch):
     Reaper.delete_instance()
-    monkeypatch.setattr(container_module, "RYUK_RECONNECTION_TIMEOUT", "0.1s")
+    monkeypatch.setattr(config, "RYUK_RECONNECTION_TIMEOUT", "0.1s")
     docker_client = DockerClient()
     container = DockerContainer("hello-world").start()
 
@@ -40,7 +40,7 @@ def test_wait_for_reaper(monkeypatch: MonkeyPatch):
 
 def test_container_without_ryuk(monkeypatch: MonkeyPatch):
     Reaper.delete_instance()
-    monkeypatch.setattr(container_module, "RYUK_DISABLED", True)
+    monkeypatch.setattr(config, "RYUK_DISABLED", True)
     with DockerContainer("hello-world") as container:
         wait_for_logs(container, "Hello from Docker!")
         assert Reaper._instance is None

--- a/modules/arangodb/testcontainers/arangodb/__init__.py
+++ b/modules/arangodb/testcontainers/arangodb/__init__.py
@@ -5,7 +5,7 @@ ArangoDB container support.
 import typing
 from os import environ
 
-from testcontainers.core.config import TIMEOUT
+from testcontainers.core import config
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -90,4 +90,4 @@ class ArangoDbContainer(DbContainer):
         return f"http://{self.get_container_host_ip()}:{port}"
 
     def _connect(self) -> None:
-        wait_for_logs(self, predicate="is ready for business", timeout=TIMEOUT)
+        wait_for_logs(self, predicate="is ready for business", timeout=config.TIMEOUT)

--- a/modules/k3s/testcontainers/k3s/__init__.py
+++ b/modules/k3s/testcontainers/k3s/__init__.py
@@ -11,7 +11,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from testcontainers.core.config import MAX_TRIES
+from testcontainers.core import config
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
@@ -46,7 +46,7 @@ class K3SContainer(DockerContainer):
         self.with_volume_mapping("/sys/fs/cgroup", "/sys/fs/cgroup", "rw")
 
     def _connect(self) -> None:
-        wait_for_logs(self, predicate="Node controller sync successful", timeout=MAX_TRIES)
+        wait_for_logs(self, predicate="Node controller sync successful", timeout=config.MAX_TRIES)
 
     def start(self) -> "K3SContainer":
         super().start()

--- a/modules/neo4j/testcontainers/neo4j/__init__.py
+++ b/modules/neo4j/testcontainers/neo4j/__init__.py
@@ -15,7 +15,7 @@ import os
 from typing import Optional
 
 from neo4j import Driver, GraphDatabase
-from testcontainers.core.config import TIMEOUT
+from testcontainers.core import config
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
@@ -62,7 +62,7 @@ class Neo4jContainer(DbContainer):
 
     @wait_container_is_ready()
     def _connect(self) -> None:
-        wait_for_logs(self, "Remote interface available at", TIMEOUT)
+        wait_for_logs(self, "Remote interface available at", config.TIMEOUT)
 
         # Then we actually check that the container really is listening
         with self.get_driver() as driver:

--- a/modules/postgres/testcontainers/postgres/__init__.py
+++ b/modules/postgres/testcontainers/postgres/__init__.py
@@ -14,7 +14,7 @@ import os
 from time import sleep
 from typing import Optional
 
-from testcontainers.core.config import MAX_TRIES, SLEEP_TIME
+from testcontainers.core import config
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
@@ -91,15 +91,15 @@ class PostgresContainer(DbContainer):
 
     @wait_container_is_ready()
     def _connect(self) -> None:
-        wait_for_logs(self, ".*database system is ready to accept connections.*", MAX_TRIES, SLEEP_TIME)
+        wait_for_logs(self, ".*database system is ready to accept connections.*", config.MAX_TRIES, config.SLEEP_TIME)
 
         count = 0
-        while count < MAX_TRIES:
+        while count < config.MAX_TRIES:
             status, _ = self.exec(f"pg_isready -hlocalhost -p{self.port} -U{self.username}")
             if status == 0:
                 return
 
-            sleep(SLEEP_TIME)
+            sleep(config.SLEEP_TIME)
             count += 1
 
         raise RuntimeError("Postgres could not get into a ready state")

--- a/modules/qdrant/testcontainers/qdrant/__init__.py
+++ b/modules/qdrant/testcontainers/qdrant/__init__.py
@@ -15,7 +15,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
-from testcontainers.core.config import TIMEOUT
+from testcontainers.core import config
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 
@@ -61,7 +61,7 @@ class QdrantContainer(DbContainer):
 
     @wait_container_is_ready()
     def _connect(self) -> None:
-        wait_for_logs(self, ".*Actix runtime found; starting in Actix runtime.*", TIMEOUT)
+        wait_for_logs(self, ".*Actix runtime found; starting in Actix runtime.*", config.TIMEOUT)
 
     def get_client(self, **kwargs):
         """


### PR DESCRIPTION
I am using testcontainers within a library that provides some pytest-fixtures.
In order for this to work I have change some settings.

As I can not guarantee that that my lib is imported before testcontainers I need to monkeypatch the settings.
This is much easier if I only need to monkeypatch the config file and not all modules that use configurations.

I would argue that for a potential library as this, this is a better design.

Also one can easier see that the given UPERCASE variable is not a constant but rather a setting. 