### PR TITLE
fix: tests for Kafka container running on ARM64 CPU

### DIFF
--- a/modules/kafka/testcontainers/kafka/__init__.py
+++ b/modules/kafka/testcontainers/kafka/__init__.py
@@ -30,7 +30,7 @@ class KafkaContainer(DockerContainer):
 
     TC_START_SCRIPT = "/tc-start.sh"
 
-    def __init__(self, image: str = "confluentinc/cp-kafka:5.4.3", port: int = 9093, **kwargs) -> None:
+    def __init__(self, image: str = "confluentinc/cp-kafka:7.6.0", port: int = 9093, **kwargs) -> None:
         raise_for_deprecated_parameter(kwargs, "port_to_expose", "port")
         super().__init__(image, **kwargs)
         self.port = port

--- a/modules/kafka/tests/test_kafka.py
+++ b/modules/kafka/tests/test_kafka.py
@@ -14,11 +14,6 @@ def test_kafka_producer_consumer_custom_port():
         produce_and_consume_kafka_message(container)
 
 
-def test_kafka_confluent_7_1_3():
-    with KafkaContainer(image="confluentinc/cp-kafka:7.1.3") as container:
-        produce_and_consume_kafka_message(container)
-
-
 def produce_and_consume_kafka_message(container):
     topic = "test-topic"
     bootstrap_server = container.get_bootstrap_server()


### PR DESCRIPTION
v5.4.3 was not supporting ARM CPUs. Removed an obsolet test.

Fixes https://github.com/testcontainers/testcontainers-python/issues/450

![Screenshot 2024-04-09 at 19 59 56](https://github.com/testcontainers/testcontainers-python/assets/13573675/ae11c272-83da-4364-ad7a-a86a128bfd24)
