### PR TITLE
fix(mysql): Add seed support in MySQL

### DIFF
--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -71,7 +71,11 @@ class DbContainer(DockerContainer):
         self._configure()
         super().start()
         self._connect()
+        self._transfer_seed()
         return self
 
     def _configure(self) -> None:
         raise NotImplementedError
+
+    def _transfer_seed(self) -> None:
+        pass

--- a/core/testcontainers/core/generic.py
+++ b/core/testcontainers/core/generic.py
@@ -70,8 +70,8 @@ class DbContainer(DockerContainer):
     def start(self) -> "DbContainer":
         self._configure()
         super().start()
-        self._connect()
         self._transfer_seed()
+        self._connect()
         return self
 
     def _configure(self) -> None:

--- a/modules/mysql/testcontainers/mysql/__init__.py
+++ b/modules/mysql/testcontainers/mysql/__init__.py
@@ -49,7 +49,7 @@ class MySqlContainer(DbContainer):
         .. doctest::
             >>> import sqlalchemy
             >>> from testcontainers.mysql import MySqlContainer
-            >>> with MySqlContainer(seed="../../tests/") as mysql:
+            >>> with MySqlContainer(seed="../../tests/seeds/") as mysql:
             ...     engine = sqlalchemy.create_engine(mysql.get_connection_url())
             ...     with engine.begin() as connection:
             ...         query = "select * from stuff"  # Can now rely on schema/data

--- a/modules/mysql/testcontainers/mysql/__init__.py
+++ b/modules/mysql/testcontainers/mysql/__init__.py
@@ -11,7 +11,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import re
+import tarfile
+from io import BytesIO
 from os import environ
+from pathlib import Path
 from typing import Optional
 
 from testcontainers.core.generic import DbContainer
@@ -85,7 +88,7 @@ class MySqlContainer(DbContainer):
         if self.username == "root":
             self.root_password = self.password
         if seed is not None:
-            self.with_volume_mapping(seed, "/docker-entrypoint-initdb.d/")
+            self.seed = seed
 
     def _configure(self) -> None:
         self.with_env("MYSQL_ROOT_PASSWORD", self.root_password)
@@ -105,3 +108,12 @@ class MySqlContainer(DbContainer):
         return super()._create_connection_url(
             dialect="mysql+pymysql", username=self.username, password=self.password, dbname=self.dbname, port=self.port
         )
+
+    def _transfer_seed(self) -> None:
+        src_path = Path(self.seed)
+        dest_path = "/docker-entrypoint-initdb.d/"
+        with BytesIO() as archive, tarfile.TarFile(fileobj=archive, mode="w") as tar:
+            for filename in src_path.iterdir():
+                tar.add(filename.absolute(), arcname=filename.relative_to(src_path))
+            archive.seek(0)
+            self.get_wrapped_container().put_archive(dest_path, archive)

--- a/modules/mysql/testcontainers/mysql/__init__.py
+++ b/modules/mysql/testcontainers/mysql/__init__.py
@@ -87,8 +87,7 @@ class MySqlContainer(DbContainer):
 
         if self.username == "root":
             self.root_password = self.password
-        if seed is not None:
-            self.seed = seed
+        self.seed = seed
 
     def _configure(self) -> None:
         self.with_env("MYSQL_ROOT_PASSWORD", self.root_password)
@@ -110,6 +109,8 @@ class MySqlContainer(DbContainer):
         )
 
     def _transfer_seed(self) -> None:
+        if self.seed is None:
+            return
         src_path = Path(self.seed)
         dest_path = "/docker-entrypoint-initdb.d/"
         with BytesIO() as archive, tarfile.TarFile(fileobj=archive, mode="w") as tar:

--- a/modules/mysql/tests/seeds/01-schema.sql
+++ b/modules/mysql/tests/seeds/01-schema.sql
@@ -1,0 +1,6 @@
+-- Sample SQL schema, no data
+CREATE TABLE `stuff` (
+ `id` mediumint NOT NULL AUTO_INCREMENT,
+ `name` VARCHAR(63) NOT NULL,
+ PRIMARY KEY (`id`)
+);

--- a/modules/mysql/tests/seeds/02-seeds.sql
+++ b/modules/mysql/tests/seeds/02-seeds.sql
@@ -1,0 +1,3 @@
+-- Sample data, to be loaded after the schema
+INSERT INTO stuff (name)
+VALUES ("foo"), ("bar"), ("qux"), ("frob");


### PR DESCRIPTION
Ref #541.
New capability of "seeding" a db container using image's support for /docker-entrypoint-initdb.d/ folder.

Using the "transferable" system, borrowed from Kafka. 

Updates DbContainer to have a new (NOOP-default) `_transfer_seed()` method, run after `_start()` and before `_connect()`, to allow the folder transfer.

Currently implemented only in MySQL, but extensible to others that use the `/docker-entrypoint-initdb.d/` system.
