### PR TITLE
Add _configure() to DockerContainer

### DIFF
--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -87,6 +87,7 @@ class DockerContainer:
             Reaper.get_instance()
         logger.info("Pulling image %s", self.image)
         docker_client = self.get_docker_client()
+        self._configure()
         self._container = docker_client.run(
             self.image,
             command=self._command,
@@ -175,6 +176,9 @@ class DockerContainer:
         if not self._container:
             raise ContainerStartException("Container should be started before executing a command")
         return self._container.exec_run(command)
+
+    def _configure(self) -> None:
+		raise NotImplementedError
 
 
 class Reaper:


### PR DESCRIPTION
I've used DbContainer in the past as a parent to a custom class where I redefine `_configure()`. I'm now using DockerContainer and wanted to follow the same pattern but it doesn't have a `_configure()` function called in `start()`.
