### PR TITLE
fix(keycloak): add realm imports

### DIFF
--- a/modules/keycloak/testcontainers/keycloak/__init__.py
+++ b/modules/keycloak/testcontainers/keycloak/__init__.py
@@ -65,7 +65,7 @@ class KeycloakContainer(DockerContainer):
         if self.has_realm_imports:
             self.cmd += " --import-realm"
         self.with_command(self.cmd)
- 
+
     def get_url(self) -> str:
         host = self.get_container_host_ip()
         port = self.get_exposed_port(self.port)
@@ -100,7 +100,7 @@ class KeycloakContainer(DockerContainer):
         self.with_volume_mapping(folder, "/opt/keycloak/data/import/")
         self.has_realm_imports = True
         return self
-    
+
     def get_client(self, **kwargs) -> KeycloakAdmin:
         default_kwargs = {
             "server_url": self.get_url(),

--- a/modules/keycloak/testcontainers/keycloak/__init__.py
+++ b/modules/keycloak/testcontainers/keycloak/__init__.py
@@ -60,7 +60,7 @@ class KeycloakContainer(DockerContainer):
         self.with_env("KC_HEALTH_ENABLED", "true")
         # Starting Keycloak in development mode
         # see: https://www.keycloak.org/server/configuration#_starting_keycloak_in_development_mode
-        cmd = f"{_DEFAULT_DEV_COMMAND} {'--import-realm' if self.has_realm_imports else ''}"
+        cmd = f"{_DEFAULT_DEV_COMMAND}{' --import-realm' if self.has_realm_imports else ''}"
         self.with_command(cmd)
  
     def get_url(self) -> str:
@@ -73,7 +73,6 @@ class KeycloakContainer(DockerContainer):
         # Keycloak provides an REST API endpoints for health checks: https://www.keycloak.org/server/health
         response = requests.get(f"{self.get_url()}/health/ready", timeout=1)
         response.raise_for_status()
-        print("Waiting until keycloak has added a user...")
         if self._command == _DEFAULT_DEV_COMMAND:
             wait_for_logs(self, "Added user .* to realm .*")
 
@@ -98,7 +97,6 @@ class KeycloakContainer(DockerContainer):
         self.with_volume_mapping(folder, "/opt/keycloak/data/import/")
         self.has_realm_imports = True
         return self
-    
     
     def get_client(self, **kwargs) -> KeycloakAdmin:
         default_kwargs = {


### PR DESCRIPTION
This PR adds an option to start a keycloak container with importing one or more realms. This mirrors a feature present in the java keycloak testcontainer.
