### PR TITLE
fix(core): remove version from compose tests

### DIFF
--- a/core/tests/compose_fixtures/basic/docker-compose.yaml
+++ b/core/tests/compose_fixtures/basic/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   alpine:
     image: alpine:latest

--- a/core/tests/compose_fixtures/port_multiple/compose.yaml
+++ b/core/tests/compose_fixtures/port_multiple/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   alpine:
     image: nginx:alpine-slim

--- a/core/tests/compose_fixtures/port_single/compose.yaml
+++ b/core/tests/compose_fixtures/port_single/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   alpine:
     image: nginx:alpine-slim


### PR DESCRIPTION
This would address #570
Removing the version from the compose.yaml files used in tests.

Please see https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313
