### PR TITLE
fix(keycloak): realm import

### DIFF
--- a/modules/keycloak/testcontainers/keycloak/__init__.py
+++ b/modules/keycloak/testcontainers/keycloak/__init__.py
@@ -80,7 +80,6 @@ class KeycloakContainer(DockerContainer):
             wait_for_logs(self, "Added user .* to realm .*")
 
     def start(self) -> "KeycloakContainer":
-        self._configure()
         super().start()
         self._readiness_probe()
         return self


### PR DESCRIPTION
With the option to import keycloak realms, introduced with #565, the[_configure()](https://github.com/testcontainers/testcontainers-python/blob/78b6f0ecb15e8cba687eb4588c5ce19ca32208bc/modules/keycloak/testcontainers/keycloak/__init__.py#L57) method is called twice. Once it is called in the [start()](https://github.com/testcontainers/testcontainers-python/blob/78b6f0ecb15e8cba687eb4588c5ce19ca32208bc/modules/keycloak/testcontainers/keycloak/__init__.py#L83) method of keycloak itself and then it is called a second time in the [start()](https://github.com/testcontainers/testcontainers-python/blob/78b6f0ecb15e8cba687eb4588c5ce19ca32208bc/core/testcontainers/core/container.py#L90) method of DockerContainer. This wasn't an issue so far. But if a realm shall be imported (self.has_realm_import in keycloak is True), then every time the string " --import-realm" is added to the start command in the _configure() method. The keycloak container won't start if "--import-realm" is specified multiple times.
This is probably the easiest solution to solve the issue. If wished, I can also work on a more robust solution, e.g. by storing the start command in a list and checking that "--import-realm" is only added once.