### PR TITLE
Set elasticseach http.port environment variable for non default ports

### DIFF
--- a/modules/elasticsearch/testcontainers/elasticsearch/__init__.py
+++ b/modules/elasticsearch/testcontainers/elasticsearch/__init__.py
@@ -79,6 +79,8 @@ class ElasticSearchContainer(DockerContainer):
         super().__init__(image, **kwargs)
         self.port = port
         self.with_exposed_ports(self.port)
+        if self.port != 9200:
+            self.with_env("http.port", str(self.port))
         self.with_env("transport.host", "127.0.0.1")
         self.with_env("http.host", "0.0.0.0")
 

--- a/modules/elasticsearch/tests/test_elasticsearch.py
+++ b/modules/elasticsearch/tests/test_elasticsearch.py
@@ -12,3 +12,10 @@ def test_docker_run_elasticsearch(version):
     with ElasticSearchContainer(f"elasticsearch:{version}", mem_limit="3G") as es:
         resp = urllib.request.urlopen(es.get_url())
         assert json.loads(resp.read().decode())["version"]["number"] == version
+
+
+@pytest.mark.parametrize("version", ["7.17.18", "8.12.2"])
+def test_docker_run_elasticsearch_custom_port(version):
+    with ElasticSearchContainer(f"elasticsearch:{version}", mem_limit="3G", port=9876) as es:
+        resp = urllib.request.urlopen(es.get_url())
+        assert json.loads(resp.read().decode())["version"]["number"] == version


### PR DESCRIPTION
I tried running test containers for a project of mine, since I already had a local instance running on 9200 (default port) I set a custom port. However, the tests seemed to fail because it couldn't connect to the instance. This is because ES expects to run on 9200, unless you set the http.port setting (which you can with an environment variable).

So I thought it might be useful to do that by default, so others don't have to debug this issue themselves.