### PR TITLE
chore: Update Weaviate default version to v1.25.5

### DIFF
--- a/modules/weaviate/testcontainers/weaviate/__init__.py
+++ b/modules/weaviate/testcontainers/weaviate/__init__.py
@@ -63,7 +63,7 @@ class WeaviateContainer(DbContainer):
 
     def __init__(
         self,
-        image: str = "semitechnologies/weaviate:1.24.5",
+        image: str = "semitechnologies/weaviate:1.25.5",
         env_vars: Optional[dict[str, str]] = None,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
This is just a small PR that updates Weaviate default version to `v1.25.5`