### PR TITLE
feat(core): Add support for ollama module

### DIFF
--- a/modules/ollama/README.rst
+++ b/modules/ollama/README.rst
@@ -1,0 +1,2 @@
+.. autoclass:: testcontainers.ollama.OllamaContainer
+.. title:: testcontainers.ollama.OllamaContainer

--- a/modules/ollama/testcontainers/ollama/__init__.py
+++ b/modules/ollama/testcontainers/ollama/__init__.py
@@ -1,0 +1,79 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import docker
+from docker.types.containers import DeviceRequest
+
+from testcontainers.core.generic import ServerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+
+class OllamaContainer(ServerContainer):
+    def __init__(self, image="ollama/ollama:latest"):
+        self.port = 11434
+        super().__init__(port=self.port, image=image)
+        self.with_exposed_ports(self.port)
+        self._check_and_add_gpu_capabilities()
+
+    def _check_and_add_gpu_capabilities(self):
+        info = docker.APIClient().info()
+        if "nvidia" in info["Runtimes"]:
+            self.with_kwargs(device_requests=DeviceRequest(count=-1, capabilities=[["gpu"]]))
+
+    def start(self) -> "OllamaContainer":
+        """
+        Start the Ollama server
+        """
+        super().start()
+        wait_container_is_ready(self, "Ollama started successfully")
+        self._connect()
+
+        return self
+
+    def get_endpoint(self):
+        """
+        Return the endpoint of the Ollama server
+        """
+        return self._create_connection_url()
+
+    @property
+    def id(self) -> str:
+        """
+        Return the container object
+        """
+        return self._container.id
+
+    def pull_model(self, model_name: str) -> None:
+        """
+        Pull a model from the Ollama server
+
+        Args:
+            model_name (str): Name of the model
+        """
+        self.exec(f"ollama pull {model_name}")
+
+    def commit_to_image(self, image_name: str) -> None:
+        """
+        Commit the current container to a new image
+
+        Args:
+            image_name (str): Name of the new image
+        """
+        docker_client = self.get_docker_client()
+        existing_images = docker_client.client.images.list(name=image_name)
+        if not existing_images and self.id:
+            docker_client.client.containers.get(self.id).commit(
+                repository=image_name,
+                tag=image_name.split(":")[-1] if ":" in image_name else "latest",
+                conf={"Labels": {"org.testcontainers.session-id": ""}},
+            )

--- a/modules/ollama/testcontainers/ollama/__init__.py
+++ b/modules/ollama/testcontainers/ollama/__init__.py
@@ -12,7 +12,7 @@
 #    under the License.
 
 from os import PathLike
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional, TypedDict, Union
 
 from docker.types.containers import DeviceRequest
 from requests import get
@@ -49,7 +49,7 @@ class OllamaContainer(DockerContainer):
     def __init__(
         self,
         image: str = "ollama/ollama:0.1.44",
-        ollama_dir: Optional[str | PathLike] = None,
+        ollama_dir: Optional[Union[str, PathLike]] = None,
         **kwargs,
         #
     ):

--- a/modules/ollama/testcontainers/ollama/__init__.py
+++ b/modules/ollama/testcontainers/ollama/__init__.py
@@ -73,7 +73,5 @@ class OllamaContainer(ServerContainer):
         existing_images = docker_client.client.images.list(name=image_name)
         if not existing_images and self.id:
             docker_client.client.containers.get(self.id).commit(
-                repository=image_name,
-                tag=image_name.split(":")[-1] if ":" in image_name else "latest",
-                conf={"Labels": {"org.testcontainers.session-id": ""}},
+                repository=image_name, conf={"Labels": {"org.testcontainers.session-id": ""}}
             )

--- a/modules/ollama/testcontainers/ollama/__init__.py
+++ b/modules/ollama/testcontainers/ollama/__init__.py
@@ -43,6 +43,7 @@ class OllamaContainer(DockerContainer):
             ...     ollama.list_models()
             []
     """
+
     OLLAMA_PORT = 11434
 
     def __init__(

--- a/modules/ollama/tests/test_ollama.py
+++ b/modules/ollama/tests/test_ollama.py
@@ -1,0 +1,46 @@
+import requests
+from testcontainers.ollama import OllamaContainer
+import random
+import string
+
+
+def random_string(length=6):
+    return "".join(random.choices(string.ascii_lowercase, k=length))
+
+
+def test_ollama_container():
+    with OllamaContainer() as ollama:
+        url = ollama.get_endpoint()
+        response = requests.get(url)
+        assert response.status_code == 200
+        assert response.text == "Ollama is running"
+
+
+def test_with_default_config():
+    with OllamaContainer("ollama/ollama:0.1.26") as ollama:
+        ollama.start()
+        response = requests.get(f"{ollama.get_endpoint()}/api/version")
+        version = response.json().get("version")
+        assert version == "0.1.26"
+
+
+def test_download_model_and_commit_to_image():
+    new_image_name = f"tc-ollama-allminilm-{random_string(length=4).lower()}"
+    with OllamaContainer("ollama/ollama:0.1.26") as ollama:
+        ollama.start()
+        # Pull the model
+        ollama.pull_model("all-minilm")
+
+        response = requests.get(f"{ollama.get_endpoint()}/api/tags")
+        model_name = response.json().get("models", [])[0].get("name")
+        assert "all-minilm" in model_name
+
+        # Commit the container state to a new image
+        ollama.commit_to_image(new_image_name)
+
+    # Verify the new image
+    with OllamaContainer(new_image_name) as ollama:
+        ollama.start()
+        response = requests.get(f"{ollama.get_endpoint()}/api/tags")
+        model_name = response.json().get("models", [])[0].get("name")
+        assert "all-minilm" in model_name

--- a/poetry.lock
+++ b/poetry.lock
@@ -1898,6 +1898,7 @@ python-versions = ">=3.7"
 files = [
     {file = "milvus_lite-2.4.7-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c828190118b104b05b8c8e0b5a4147811c86b54b8fb67bc2e726ad10fc0b544e"},
     {file = "milvus_lite-2.4.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1537633c39879714fb15082be56a4b97f74c905a6e98e302ec01320561081af"},
+    {file = "milvus_lite-2.4.7-py3-none-manylinux2014_aarch64.whl", hash = "sha256:fcb909d38c83f21478ca9cb500c84264f988c69f62715ae9462e966767fb76dd"},
     {file = "milvus_lite-2.4.7-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f016474d663045787dddf1c3aad13b7d8b61fd329220318f858184918143dcbf"},
 ]
 
@@ -4479,6 +4480,7 @@ mysql = ["pymysql", "sqlalchemy"]
 nats = ["nats-py"]
 neo4j = ["neo4j"]
 nginx = []
+ollama = []
 opensearch = ["opensearch-py"]
 oracle = ["oracledb", "sqlalchemy"]
 oracle-free = ["oracledb", "sqlalchemy"]
@@ -4494,4 +4496,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "040fa3576807a8bd7b129b889c934d5c4bca9e95376c50e15fa870f4d8336fdb"
+content-hash = "6f7697a84a674802e30ceea61276d800b6b98224863a0c512138447d9b4af524"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ packages = [
     { include = "testcontainers", from = "modules/nats" },
     { include = "testcontainers", from = "modules/neo4j" },
     { include = "testcontainers", from = "modules/nginx" },
+    { include = "testcontainers", from = "modules/ollama" },
     { include = "testcontainers", from = "modules/opensearch" },
     { include = "testcontainers", from = "modules/oracle-free" },
     { include = "testcontainers", from = "modules/postgres" },
@@ -127,6 +128,7 @@ nats = ["nats-py"]
 neo4j = ["neo4j"]
 nginx = []
 opensearch = ["opensearch-py"]
+ollama = []
 oracle = ["sqlalchemy", "oracledb"]
 oracle-free = ["sqlalchemy", "oracledb"]
 postgres = []
@@ -272,6 +274,7 @@ mypy_path = [
 #    "modules/mysql",
 #    "modules/neo4j",
 #    "modules/nginx",
+#    "modules/ollama",
 #    "modules/opensearch",
 #    "modules/oracle",
 #    "modules/postgres",


### PR DESCRIPTION
- Added a new class OllamaContainer with few methods to handle the Ollama container.

- The `_check_and_add_gpu_capabilities` method checks if the host has GPUs and adds the necessary capabilities to the container.

- The `commit_to_image` allows to save somehow the state of a container into an image so that we can reuse it, especially for the ones having some models pulled.
- Added tests to check the functionality of the new class.

> Note: I inspired myself from the java implementation of the Ollama module.

Fixes #617 