### PR TITLE
feat(core): DockerCompose.stop now stops only services that it starts (does not stop the other services)

### DIFF
--- a/core/testcontainers/compose/compose.py
+++ b/core/testcontainers/compose/compose.py
@@ -236,6 +236,10 @@ class DockerCompose:
             down_cmd += ["down", "--volumes"]
         else:
             down_cmd += ["stop"]
+
+        if self.services:
+            down_cmd.extend(self.services)
+
         self._run_command(cmd=down_cmd)
 
     def get_logs(self, *services: str) -> tuple[str, str]:

--- a/core/tests/compose_fixtures/basic_multiple/docker-compose.yaml
+++ b/core/tests/compose_fixtures/basic_multiple/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  alpine1:
+    image: alpine:latest
+    init: true
+    command:
+      - sh
+      - -c
+      - 'while true; do sleep 0.1 ; date -Ins; done'
+  alpine2:
+    image: alpine:latest
+    init: true
+    command:
+      - sh
+      - -c
+      - 'while true; do sleep 0.1 ; date -Ins; done'


### PR DESCRIPTION
The command would otherwise stop/down all services, not just the services the instance itself started.

Useful for e.g. one fixture per service, and you want different scopes for the services.