### PR TITLE
fix(network): Now able to use Network without context, and has labels to be automatically cleaned up (#627)

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -211,6 +211,10 @@ class DockerClient:
         login_info = self.client.login(**auth_config._asdict())
         LOGGER.debug(f"logged in using {login_info}")
 
+    def client_networks_create(self, name: str, param: dict):
+        labels = create_labels("", param.get("labels"))
+        return self.client.networks.create(name, **{**param, "labels": labels})
+
 
 def get_docker_host() -> Optional[str]:
     return c.tc_properties_get_tc_host() or os.getenv("DOCKER_HOST")

--- a/core/testcontainers/core/network.py
+++ b/core/testcontainers/core/network.py
@@ -32,10 +32,13 @@ class Network:
     def remove(self) -> None:
         self._network.remove()
 
-    def __enter__(self) -> "Network":
+    def create(self) -> "Network":
         self._network = self._docker.client.networks.create(self.name, **self._docker_network_kw)
         self.id = self._network.id
         return self
+
+    def __enter__(self) -> "Network":
+        return self.create()
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.remove()

--- a/core/testcontainers/core/network.py
+++ b/core/testcontainers/core/network.py
@@ -33,7 +33,7 @@ class Network:
         self._network.remove()
 
     def create(self) -> "Network":
-        self._network = self._docker.client.networks.create(self.name, **self._docker_network_kw)
+        self._network = self._docker.client_networks_create(self.name, self._docker_network_kw)
         self.id = self._network.id
         return self
 

--- a/core/tests/test_network.py
+++ b/core/tests/test_network.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
+from testcontainers.core.labels import LABEL_SESSION_ID
 from testcontainers.core.network import Network
 
 import docker.errors
@@ -70,3 +71,13 @@ def assert_can_ping(container: DockerContainer, remote_name: str):
     status, output = container.exec("ping -c 1 %s" % remote_name)
     assert status == 0
     assert "64 bytes" in str(output)
+
+
+def test_network_has_labels():
+    network = Network()
+    try:
+        network.create()
+        network = network._docker.client.networks.get(network_id=network.id)
+        assert LABEL_SESSION_ID in network.attrs.get("Labels")
+    finally:
+        network.remove()


### PR DESCRIPTION
This PR adds `create` method to the `Network` class to enable a non-context-manager usage.

Fixes #627