### PR TITLE
fix(kafka): add a flag to limit to first hostname for use with networks

### DIFF
--- a/modules/kafka/tests/test_kafka.py
+++ b/modules/kafka/tests/test_kafka.py
@@ -1,6 +1,8 @@
-from kafka import KafkaConsumer, KafkaProducer, TopicPartition
+import pytest
+from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer, TopicPartition
 
-from testcontainers.kafka import KafkaContainer
+from testcontainers.core.network import Network
+from testcontainers.kafka import KafkaContainer, kafka_config
 
 
 def test_kafka_producer_consumer():
@@ -18,6 +20,23 @@ def test_kafka_producer_consumer_custom_port():
     with KafkaContainer(port=9888) as container:
         assert container.port == 9888
         produce_and_consume_kafka_message(container)
+
+
+def test_kafka_on_networks(monkeypatch: pytest.MonkeyPatch):
+    """
+    this test case comes from testcontainers/testcontainers-python#637
+    """
+    monkeypatch.setattr(kafka_config, "limit_broker_to_first_host", True)
+
+    with Network() as network:
+        kafka_ctr = KafkaContainer()
+        kafka_ctr.with_network(network)
+        kafka_ctr.with_network_aliases("kafka")
+
+        with kafka_ctr:
+            print("started")  # Will not reach here and timeout
+            admin_client = KafkaAdminClient(bootstrap_servers=[kafka_ctr.get_bootstrap_server()])
+            print(admin_client.describe_cluster())
 
 
 def produce_and_consume_kafka_message(container):


### PR DESCRIPTION
fix #637
