### PR TITLE
fix(core): tolerate `DOCKER_AUTH_CONFIG` with schemas that are not implemented in tc-python

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -207,9 +207,11 @@ class DockerClient:
         """
         Login to a docker registry using the given auth config.
         """
-        auth_config = parse_docker_auth_config(docker_auth_config)[0]  # Only using the first auth config
-        login_info = self.client.login(**auth_config._asdict())
-        LOGGER.debug(f"logged in using {login_info}")
+        auth_config = parse_docker_auth_config(docker_auth_config)
+        if auth_config:
+            first_auth_config = auth_config[0]  # Only using the first auth config
+            login_info = self.client.login(**first_auth_config._asdict())
+            LOGGER.debug(f"logged in using {login_info}")
 
     def client_networks_create(self, name: str, param: dict):
         labels = create_labels("", param.get("labels"))

--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -99,7 +99,7 @@ def parse_docker_auth_config(auth_config: str) -> list[DockerAuthInfo]:
     """
     auth_info: list[DockerAuthInfo] = []
     try:
-        auth_config_dict: dict = json.loads(auth_config).get("auths")
+        auth_config_dict: dict = json.loads(auth_config).get("auths", {})
         for registry, auth in auth_config_dict.items():
             auth_str = auth.get("auth")
             auth_str = base64.b64decode(auth_str).decode("utf-8")

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -40,3 +40,10 @@ def test_parse_docker_auth_config_multiple():
         username="abc",
         password="123",
     )
+
+
+def test_parse_docker_auth_config_with_no_auths():
+    auth_dict = {"credHelpers": {"<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"}}
+    auth_config_json = json.dumps(auth_dict)
+    auth_info = parse_docker_auth_config(auth_config_json)
+    assert len(auth_info) == 0


### PR DESCRIPTION
since this env var might be set in the env targetting software other than this library, this library should silently ignore what it considers to be invalid input
