### PR TITLE
fix(core): Improve private registry support (tolerate not implemented fields in DOCKER_AUTH_CONFIG)

### DIFF
--- a/core/testcontainers/core/auth.py
+++ b/core/testcontainers/core/auth.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 DockerAuthInfo = namedtuple("DockerAuthInfo", ["registry", "username", "password"])
 
-_WARNINGS = {
+_AUTH_WARNINGS = {
     "credHelpers": "DOCKER_AUTH_CONFIG is experimental, credHelpers not supported yet",
     "credsStore": "DOCKER_AUTH_CONFIG is experimental, credsStore not supported yet",
 }
@@ -50,7 +50,8 @@ def parse_docker_auth_config_cred_helpers(auth_config_dict: dict) -> None:
 
     This is not supported yet.
     """
-    warning(_WARNINGS.pop("credHelpers"))
+    if "credHelpers" in _AUTH_WARNINGS:
+        warning(_AUTH_WARNINGS.pop("credHelpers"))
 
 
 def parse_docker_auth_config_store(auth_config_dict: dict) -> None:
@@ -64,7 +65,8 @@ def parse_docker_auth_config_store(auth_config_dict: dict) -> None:
 
     This is not supported yet.
     """
-    warning(_WARNINGS.pop("credsStore"))
+    if "credsStore" in _AUTH_WARNINGS:
+        warning(_AUTH_WARNINGS.pop("credsStore"))
 
 
 def parse_docker_auth_config(auth_config: str) -> Optional[list[DockerAuthInfo]]:

--- a/core/testcontainers/core/auth.py
+++ b/core/testcontainers/core/auth.py
@@ -1,0 +1,74 @@
+import base64 as base64
+import json as json
+from collections import namedtuple as namedtuple
+from logging import warning
+
+DockerAuthInfo = namedtuple("DockerAuthInfo", ["registry", "username", "password"])
+
+_WARNINGS = {
+    "credHelpers": "DOCKER_AUTH_CONFIG is experimental, credHelpers not supported yet",
+    "credsStore": "DOCKER_AUTH_CONFIG is experimental, credsStore not supported yet",
+}
+
+
+def parse_docker_auth_config_encoded(auth_config: str) -> list[DockerAuthInfo]:
+    """
+    Parse the docker auth config from a string.
+
+    Example:
+    {
+        "auths": {
+            "https://index.docker.io/v1/": {
+                "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+            }
+        }
+    }
+    """
+    auth_info: list[DockerAuthInfo] = []
+    try:
+        auth_config_dict: dict = json.loads(auth_config).get("auths")
+        for registry, auth in auth_config_dict.items():
+            auth_str = auth.get("auth")
+            auth_str = base64.b64decode(auth_str).decode("utf-8")
+            username, password = auth_str.split(":")
+            auth_info.append(DockerAuthInfo(registry, username, password))
+        return auth_info
+    except (json.JSONDecodeError, KeyError, ValueError) as exp:
+        raise ValueError("Could not parse docker auth config") from exp
+
+
+def parse_docker_auth_config_cred_helpers(auth_config: str) -> None:
+    """
+    Parse the docker auth config from a string.
+
+    Example:
+    {
+        "credHelpers": {
+            "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"
+        }
+    }
+    """
+    warning(_WARNINGS.pop("credHelpers"))
+
+
+def parse_docker_auth_config_store(auth_config: str) -> None:
+    """
+    Parse the docker auth config from a string.
+
+    Example:
+    {
+        "credsStore": "ecr-login"
+    }
+    """
+    warning(_WARNINGS.pop("credsStore"))
+
+
+def parse_docker_auth_config(auth_config: str) -> list[DockerAuthInfo]:
+    if "auths" in auth_config:
+        return parse_docker_auth_config_encoded(auth_config)
+    elif "credHelpers" in auth_config:
+        parse_docker_auth_config_cred_helpers(auth_config)
+    elif "credsStore" in auth_config:
+        parse_docker_auth_config_store(auth_config)
+    else:
+        raise ValueError("Could not parse docker auth config")

--- a/core/testcontainers/core/auth.py
+++ b/core/testcontainers/core/auth.py
@@ -47,6 +47,8 @@ def parse_docker_auth_config_cred_helpers(auth_config_dict: dict) -> None:
             "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"
         }
     }
+
+    This is not supported yet.
     """
     warning(_WARNINGS.pop("credHelpers"))
 
@@ -59,6 +61,8 @@ def parse_docker_auth_config_store(auth_config_dict: dict) -> None:
     {
         "credsStore": "ecr-login"
     }
+
+    This is not supported yet.
     """
     warning(_WARNINGS.pop("credsStore"))
 

--- a/core/testcontainers/core/auth.py
+++ b/core/testcontainers/core/auth.py
@@ -75,12 +75,12 @@ def parse_docker_auth_config(auth_config: str) -> Optional[list[DockerAuthInfo]]
     """Parse the docker auth config from a string and handle the different formats."""
     try:
         auth_config_dict: dict = json.loads(auth_config)
+        if "credHelpers" in auth_config:
+            process_docker_auth_config_cred_helpers(auth_config_dict)
+        if "credsStore" in auth_config:
+            process_docker_auth_config_store(auth_config_dict)
         if "auths" in auth_config:
             return process_docker_auth_config_encoded(auth_config_dict)
-        elif "credHelpers" in auth_config:
-            process_docker_auth_config_cred_helpers(auth_config_dict)
-        elif "credsStore" in auth_config:
-            process_docker_auth_config_store(auth_config_dict)
 
     except (json.JSONDecodeError, KeyError, ValueError) as exp:
         raise ValueError("Could not parse docker auth config") from exp

--- a/core/testcontainers/core/auth.py
+++ b/core/testcontainers/core/auth.py
@@ -12,9 +12,9 @@ _AUTH_WARNINGS = {
 }
 
 
-def parse_docker_auth_config_encoded(auth_config_dict: dict) -> list[DockerAuthInfo]:
+def process_docker_auth_config_encoded(auth_config_dict: dict) -> list[DockerAuthInfo]:
     """
-    Parse the docker auth config from a string.
+    Process the auths config.
 
     Example:
     {
@@ -24,6 +24,8 @@ def parse_docker_auth_config_encoded(auth_config_dict: dict) -> list[DockerAuthI
             }
         }
     }
+
+    Returns a list of DockerAuthInfo objects.
     """
     auth_info: list[DockerAuthInfo] = []
 
@@ -37,9 +39,9 @@ def parse_docker_auth_config_encoded(auth_config_dict: dict) -> list[DockerAuthI
     return auth_info
 
 
-def parse_docker_auth_config_cred_helpers(auth_config_dict: dict) -> None:
+def process_docker_auth_config_cred_helpers(auth_config_dict: dict) -> None:
     """
-    Parse the docker auth config from a string.
+    Process the credHelpers config.
 
     Example:
     {
@@ -54,9 +56,9 @@ def parse_docker_auth_config_cred_helpers(auth_config_dict: dict) -> None:
         warning(_AUTH_WARNINGS.pop("credHelpers"))
 
 
-def parse_docker_auth_config_store(auth_config_dict: dict) -> None:
+def process_docker_auth_config_store(auth_config_dict: dict) -> None:
     """
-    Parse the docker auth config from a string.
+    Process the credsStore config.
 
     Example:
     {
@@ -74,11 +76,11 @@ def parse_docker_auth_config(auth_config: str) -> Optional[list[DockerAuthInfo]]
     try:
         auth_config_dict: dict = json.loads(auth_config)
         if "auths" in auth_config:
-            return parse_docker_auth_config_encoded(auth_config_dict)
+            return process_docker_auth_config_encoded(auth_config_dict)
         elif "credHelpers" in auth_config:
-            parse_docker_auth_config_cred_helpers(auth_config_dict)
+            process_docker_auth_config_cred_helpers(auth_config_dict)
         elif "credsStore" in auth_config:
-            parse_docker_auth_config_store(auth_config_dict)
+            process_docker_auth_config_store(auth_config_dict)
 
     except (json.JSONDecodeError, KeyError, ValueError) as exp:
         raise ValueError("Could not parse docker auth config") from exp

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -24,9 +24,10 @@ from docker.models.containers import Container, ContainerCollection
 from docker.models.images import Image, ImageCollection
 from typing_extensions import ParamSpec
 
+from testcontainers.core.auth import parse_docker_auth_config
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.labels import SESSION_ID, create_labels
-from testcontainers.core.utils import default_gateway_ip, inside_container, parse_docker_auth_config, setup_logger
+from testcontainers.core.utils import default_gateway_ip, inside_container, setup_logger
 
 LOGGER = setup_logger(__name__)
 

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -24,7 +24,7 @@ from docker.models.containers import Container, ContainerCollection
 from docker.models.images import Image, ImageCollection
 from typing_extensions import ParamSpec
 
-from testcontainers.core.auth import parse_docker_auth_config
+from testcontainers.core.auth import DockerAuthInfo, parse_docker_auth_config
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.labels import SESSION_ID, create_labels
 from testcontainers.core.utils import default_gateway_ip, inside_container, setup_logger
@@ -68,8 +68,11 @@ class DockerClient:
         self.client.api.headers["x-tc-sid"] = SESSION_ID
         self.client.api.headers["User-Agent"] = "tc-python/" + importlib.metadata.version("testcontainers")
 
+        # Verify if we have a docker auth config and login if we do
         if docker_auth_config := get_docker_auth_config():
-            self.login(docker_auth_config)
+            LOGGER.debug(f"DOCKER_AUTH_CONFIG found: {docker_auth_config}")
+            if auth_config := parse_docker_auth_config(docker_auth_config):
+                self.login(auth_config[0])  # Only using the first auth config)
 
     @_wrapped_container_collection
     def run(
@@ -204,11 +207,10 @@ class DockerClient:
                 return ip_address
         return "localhost"
 
-    def login(self, docker_auth_config: str) -> None:
+    def login(self, auth_config: DockerAuthInfo) -> None:
         """
         Login to a docker registry using the given auth config.
         """
-        auth_config = parse_docker_auth_config(docker_auth_config)[0]  # Only using the first auth config
         login_info = self.client.login(**auth_config._asdict())
         LOGGER.debug(f"logged in using {login_info}")
 

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -24,7 +24,7 @@ from docker.models.containers import Container, ContainerCollection
 from docker.models.images import Image, ImageCollection
 from typing_extensions import ParamSpec
 
-from testcontainers.core.auth import DockerAuthInfo, parse_docker_auth_config
+from testcontainers.core.auth import parse_docker_auth_config
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.labels import SESSION_ID, create_labels
 from testcontainers.core.utils import default_gateway_ip, inside_container, setup_logger
@@ -68,8 +68,8 @@ class DockerClient:
         self.client.api.headers["x-tc-sid"] = SESSION_ID
         self.client.api.headers["User-Agent"] = "tc-python/" + importlib.metadata.version("testcontainers")
 
-        if auth_config := get_docker_auth_config():
-            self.login(auth_config)
+        if docker_auth_config := get_docker_auth_config():
+            self.login(docker_auth_config)
 
     @_wrapped_container_collection
     def run(
@@ -204,11 +204,11 @@ class DockerClient:
                 return ip_address
         return "localhost"
 
-    def login(self, auth_config: DockerAuthInfo) -> None:
+    def login(self, docker_auth_config: str) -> None:
         """
         Login to a docker registry using the given auth config.
         """
-
+        auth_config = parse_docker_auth_config(docker_auth_config)[0]  # Only using the first auth config
         login_info = self.client.login(**auth_config._asdict())
         LOGGER.debug(f"logged in using {login_info}")
 
@@ -221,10 +221,5 @@ def get_docker_host() -> Optional[str]:
     return c.tc_properties_get_tc_host() or os.getenv("DOCKER_HOST")
 
 
-def get_docker_auth_config() -> Optional[DockerAuthInfo]:
-    if c.docker_auth_config:
-        auth_config = parse_docker_auth_config(c.docker_auth_config)
-        if auth_config:
-            return auth_config[0]  # Only using the first auth config found
-
-    return None
+def get_docker_auth_config() -> Optional[str]:
+    return c.docker_auth_config

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -24,7 +24,7 @@ from docker.models.containers import Container, ContainerCollection
 from docker.models.images import Image, ImageCollection
 from typing_extensions import ParamSpec
 
-from testcontainers.core.auth import parse_docker_auth_config
+from testcontainers.core.auth import DockerAuthInfo, parse_docker_auth_config
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.labels import SESSION_ID, create_labels
 from testcontainers.core.utils import default_gateway_ip, inside_container, setup_logger
@@ -68,8 +68,8 @@ class DockerClient:
         self.client.api.headers["x-tc-sid"] = SESSION_ID
         self.client.api.headers["User-Agent"] = "tc-python/" + importlib.metadata.version("testcontainers")
 
-        if docker_auth_config := get_docker_auth_config():
-            self.login(docker_auth_config)
+        if auth_config := get_docker_auth_config():
+            self.login(auth_config)
 
     @_wrapped_container_collection
     def run(
@@ -204,11 +204,11 @@ class DockerClient:
                 return ip_address
         return "localhost"
 
-    def login(self, docker_auth_config: str) -> None:
+    def login(self, auth_config: DockerAuthInfo) -> None:
         """
         Login to a docker registry using the given auth config.
         """
-        auth_config = parse_docker_auth_config(docker_auth_config)[0]  # Only using the first auth config
+
         login_info = self.client.login(**auth_config._asdict())
         LOGGER.debug(f"logged in using {login_info}")
 
@@ -221,5 +221,10 @@ def get_docker_host() -> Optional[str]:
     return c.tc_properties_get_tc_host() or os.getenv("DOCKER_HOST")
 
 
-def get_docker_auth_config() -> Optional[str]:
-    return c.docker_auth_config
+def get_docker_auth_config() -> Optional[DockerAuthInfo]:
+    if c.docker_auth_config:
+        auth_config = parse_docker_auth_config(c.docker_auth_config)
+        if auth_config:
+            return auth_config[0]  # Only using the first auth config found
+
+    return None

--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -1,17 +1,12 @@
-import base64
-import json
 import logging
 import os
 import platform
 import subprocess
 import sys
-from collections import namedtuple
 
 LINUX = "linux"
 MAC = "mac"
 WIN = "win"
-
-DockerAuthInfo = namedtuple("DockerAuthInfo", ["registry", "username", "password"])
 
 
 def setup_logger(name: str) -> logging.Logger:
@@ -82,29 +77,3 @@ def raise_for_deprecated_parameter(kwargs: dict, name: str, replacement: str) ->
     if kwargs.pop(name, None):
         raise ValueError(f"Use `{replacement}` instead of `{name}`")
     return kwargs
-
-
-def parse_docker_auth_config(auth_config: str) -> list[DockerAuthInfo]:
-    """
-    Parse the docker auth config from a string.
-
-    Example:
-    {
-        "auths": {
-            "https://index.docker.io/v1/": {
-                "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
-            }
-        }
-    }
-    """
-    auth_info: list[DockerAuthInfo] = []
-    try:
-        auth_config_dict: dict = json.loads(auth_config).get("auths")
-        for registry, auth in auth_config_dict.items():
-            auth_str = auth.get("auth")
-            auth_str = base64.b64decode(auth_str).decode("utf-8")
-            username, password = auth_str.split(":")
-            auth_info.append(DockerAuthInfo(registry, username, password))
-        return auth_info
-    except (json.JSONDecodeError, KeyError, ValueError) as exp:
-        raise ValueError("Could not parse docker auth config") from exp

--- a/core/tests/test_auth.py
+++ b/core/tests/test_auth.py
@@ -3,7 +3,7 @@ import json
 from testcontainers.core.auth import parse_docker_auth_config, DockerAuthInfo
 
 
-def test_parse_docker_auth_config():
+def test_parse_docker_auth_config_encoded():
     auth_config_json = '{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcm5hbWU6cGFzc3dvcmQ="}}}'
     auth_info = parse_docker_auth_config(auth_config_json)
     assert len(auth_info) == 1
@@ -14,7 +14,19 @@ def test_parse_docker_auth_config():
     )
 
 
-def test_parse_docker_auth_config_multiple():
+def test_parse_docker_auth_config_cred_helpers():
+    auth_dict = {"credHelpers": {"<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"}}
+    auth_config_json = json.dumps(auth_dict)
+    assert parse_docker_auth_config(auth_config_json) is None
+
+
+def test_parse_docker_auth_config_store():
+    auth_dict = {"credsStore": "ecr-login"}
+    auth_config_json = json.dumps(auth_dict)
+    assert parse_docker_auth_config(auth_config_json) is None
+
+
+def test_parse_docker_auth_config_encoded_multiple():
     auth_dict = {
         "auths": {
             "localhost:5000": {"auth": "dXNlcjE6cGFzczE=="},

--- a/core/tests/test_auth.py
+++ b/core/tests/test_auth.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from testcontainers.core.auth import parse_docker_auth_config, DockerAuthInfo
 
@@ -52,3 +53,14 @@ def test_parse_docker_auth_config_encoded_multiple():
         username="abc",
         password="123",
     )
+
+
+def test_parse_docker_auth_config_unknown():
+    auth_config_str = '{"key": "value"}'
+    assert parse_docker_auth_config(auth_config_str) is None
+
+
+def test_parse_docker_auth_config_error():
+    auth_config_str = "bad//string"
+    with pytest.raises(ValueError):
+        parse_docker_auth_config(auth_config_str)

--- a/core/tests/test_auth.py
+++ b/core/tests/test_auth.py
@@ -1,6 +1,6 @@
 import json
 
-from testcontainers.core.utils import parse_docker_auth_config, DockerAuthInfo
+from testcontainers.core.auth import parse_docker_auth_config, DockerAuthInfo
 
 
 def test_parse_docker_auth_config():

--- a/core/tests/test_auth.py
+++ b/core/tests/test_auth.py
@@ -64,3 +64,21 @@ def test_parse_docker_auth_config_error():
     auth_config_str = "bad//string"
     with pytest.raises(ValueError):
         parse_docker_auth_config(auth_config_str)
+
+
+def test_parse_docker_auth_all():
+    test_dict = {
+        "auths": {
+            "localhost:5000": {"auth": "dXNlcjE6cGFzczE=="},
+        },
+        "credHelpers": {"<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"},
+        "credsStore": "ecr-login",
+    }
+    auth_config_json = json.dumps(test_dict)
+    assert parse_docker_auth_config(auth_config_json) == [
+        DockerAuthInfo(
+            registry="localhost:5000",
+            username="user1",
+            password="pass1",
+        )
+    ]

--- a/core/tests/test_docker_client.py
+++ b/core/tests/test_docker_client.py
@@ -8,7 +8,7 @@ import docker
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
-from testcontainers.core.utils import parse_docker_auth_config
+from testcontainers.core.auth import parse_docker_auth_config
 from testcontainers.core.image import DockerImage
 
 

--- a/core/tests/test_docker_client.py
+++ b/core/tests/test_docker_client.py
@@ -1,4 +1,5 @@
 import os
+import json
 from collections import namedtuple
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,8 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.auth import parse_docker_auth_config
 from testcontainers.core.image import DockerImage
+
+from pytest import mark
 
 
 def test_docker_client_from_env():
@@ -46,6 +49,55 @@ def test_docker_client_login():
         DockerClient()
 
     mock_docker.from_env.return_value.login.assert_called_with(**{"value": "test"})
+
+
+def test_docker_client_login_empty_get_docker_auth_config():
+    mock_docker = MagicMock(spec=docker)
+    mock_get_docker_auth_config = MagicMock()
+    mock_get_docker_auth_config.return_value = None
+
+    with (
+        mock.patch.object(c, "_docker_auth_config", "test"),
+        patch("testcontainers.core.docker_client.docker", mock_docker),
+        patch("testcontainers.core.docker_client.get_docker_auth_config", mock_get_docker_auth_config),
+    ):
+        DockerClient()
+
+    mock_docker.from_env.return_value.login.assert_not_called()
+
+
+def test_docker_client_login_empty_parse_docker_auth_config():
+    mock_docker = MagicMock(spec=docker)
+    mock_parse_docker_auth_config = MagicMock(spec=parse_docker_auth_config)
+    mock_utils = MagicMock()
+    mock_utils.parse_docker_auth_config = mock_parse_docker_auth_config
+    mock_parse_docker_auth_config.return_value = None
+
+    with (
+        mock.patch.object(c, "_docker_auth_config", "test"),
+        patch("testcontainers.core.docker_client.docker", mock_docker),
+        patch("testcontainers.core.docker_client.parse_docker_auth_config", mock_parse_docker_auth_config),
+    ):
+        DockerClient()
+
+    mock_docker.from_env.return_value.login.assert_not_called()
+
+
+# This is used to make sure we don't fail (nor try to login) when we have unsupported auth config
+@mark.parametrize("auth_config_sample", [{"credHelpers": {"test": "login"}}, {"credsStore": "login"}])
+def test_docker_client_login_unsupported_auth_config(auth_config_sample):
+    mock_docker = MagicMock(spec=docker)
+    mock_get_docker_auth_config = MagicMock()
+    mock_get_docker_auth_config.return_value = json.dumps(auth_config_sample)
+
+    with (
+        mock.patch.object(c, "_docker_auth_config", "test"),
+        patch("testcontainers.core.docker_client.docker", mock_docker),
+        patch("testcontainers.core.docker_client.get_docker_auth_config", mock_get_docker_auth_config),
+    ):
+        DockerClient()
+
+    mock_docker.from_env.return_value.login.assert_not_called()
 
 
 def test_container_docker_client_kw():


### PR DESCRIPTION
Continuing #562, got some feedback regarding an issue with unsupported use cases.
In this PR we will try to:
1. Map the use cases
2. Raise a warning regarding unsupported uses cases (hopefully they will be added later)
3. Address/Fix the issue where unsupported JSON schema for `DOCKER_AUTH_CONFIG` leads to an error

As always any feedback will be much appreciated.
_Please note this PR does not implement all use-cases just does a better job at preparing and handling them for now_