### PR TITLE
feat(compose): add ability to get docker compose config

### DIFF
--- a/core/tests/test_compose.py
+++ b/core/tests/test_compose.py
@@ -318,6 +318,7 @@ def test_compose_config(context: Path, mocker: MockerFixture) -> None:
 
     assert received_config
     assert isinstance(received_config, dict)
+    assert "services" in received_config
     assert run_command.call_args.kwargs["cmd"] == expected_cmd
 
 
@@ -339,6 +340,7 @@ def test_compose_config_raw(context: Path, mocker: MockerFixture) -> None:
 
     assert received_config
     assert isinstance(received_config, dict)
+    assert "services" in received_config
     assert run_command.call_args.kwargs["cmd"] == expected_cmd
 
 

--- a/core/tests/test_compose.py
+++ b/core/tests/test_compose.py
@@ -6,6 +6,7 @@ from typing import Union
 from urllib.request import urlopen, Request
 
 import pytest
+from pytest_mock import MockerFixture
 
 from testcontainers.compose import DockerCompose, ContainerIsNotRunning, NoSuchPortExposed
 
@@ -302,6 +303,43 @@ def test_exec_in_container_multiple():
         code, body = fetch(url)
         assert code == 200
         assert "test_exec_in_container" in body
+
+
+CONTEXT_FIXTURES = [pytest.param(ctx, id=ctx.name) for ctx in FIXTURES.iterdir()]
+
+
+@pytest.mark.parametrize("context", CONTEXT_FIXTURES)
+def test_compose_config(context: Path, mocker: MockerFixture) -> None:
+    compose = DockerCompose(context)
+    run_command = mocker.spy(compose, "_run_command")
+    expected_cmd = [*compose.compose_command_property, "config", "--format", "json"]
+
+    received_config = compose.get_config()
+
+    assert received_config
+    assert isinstance(received_config, dict)
+    assert run_command.call_args.kwargs["cmd"] == expected_cmd
+
+
+@pytest.mark.parametrize("context", CONTEXT_FIXTURES)
+def test_compose_config_raw(context: Path, mocker: MockerFixture) -> None:
+    compose = DockerCompose(context)
+    run_command = mocker.spy(compose, "_run_command")
+    expected_cmd = [
+        *compose.compose_command_property,
+        "config",
+        "--format",
+        "json",
+        "--no-path-resolution",
+        "--no-normalize",
+        "--no-interpolate",
+    ]
+
+    received_config = compose.get_config(path_resolution=False, normalize=False, interpolate=False)
+
+    assert received_config
+    assert isinstance(received_config, dict)
+    assert run_command.call_args.kwargs["cmd"] == expected_cmd
 
 
 def fetch(req: Union[Request, str]):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1913,6 +1913,7 @@ python-versions = ">=3.7"
 files = [
     {file = "milvus_lite-2.4.7-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c828190118b104b05b8c8e0b5a4147811c86b54b8fb67bc2e726ad10fc0b544e"},
     {file = "milvus_lite-2.4.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1537633c39879714fb15082be56a4b97f74c905a6e98e302ec01320561081af"},
+    {file = "milvus_lite-2.4.7-py3-none-manylinux2014_aarch64.whl", hash = "sha256:fcb909d38c83f21478ca9cb500c84264f988c69f62715ae9462e966767fb76dd"},
     {file = "milvus_lite-2.4.7-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f016474d663045787dddf1c3aad13b7d8b61fd329220318f858184918143dcbf"},
 ]
 
@@ -3377,6 +3378,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-arango"
 version = "7.9.1"
 description = "Python Driver for ArangoDB"
@@ -4603,4 +4621,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "00155615fffa7f316221c1fafb895105911a3cce003b57713d9b76b7fd3e3214"
+content-hash = "88b63308cfdc3de3002a4cb4f60aeff9d049bb057fd78f5a2711aff5aba59b03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ paho-mqtt = "2.1.0"
 sqlalchemy-cockroachdb = "2.0.2"
 paramiko = "^3.4.0"
 types-paramiko = "^3.4.0.20240423"
+pytest-mock = "^3.14.0"
 
 [[tool.poetry.source]]
 name = "PyPI"


### PR DESCRIPTION
This PR add a new function to the `testcontainers.compose.DockerComposer` class, `get_config` which use `docker compose config` command for resolving and returning the actual docker compose configuration.

This can be useful for example if you want to retrieve a connection string you pass to your app in your docker compose in order to connect to your database service instead of copy pasting it from your compose file into your tests.

Also note thats its way easier to rely on docker compose config to get you the config than trying to manually find, read and merge compose files in specified context (I tried it first ...).

About the tests I mostly ensured the docker compose command was as expected. This is because the config produced by the docker compose can not always reflect exactly what is in the file. There is some normalization/resolving which is done (even when you pass all flags to disable them). But anyway, I'm not sure its a good idea to actually test the behavior of the docker config command itself. 

Let me know what you think of it!