### PR TITLE
fix: wait_for_logs can now fail early when the container stops

### DIFF
--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -83,6 +83,7 @@ def wait_for_logs(
     timeout: float = config.timeout,
     interval: float = 1,
     predicate_streams_and: bool = False,
+    raise_on_exit: bool = False
     #
 ) -> float:
     """
@@ -117,4 +118,6 @@ def wait_for_logs(
             return duration
         if duration > timeout:
             raise TimeoutError(f"Container did not emit logs satisfying predicate in {timeout:.3f} " "seconds")
+        if raise_on_exit and container.get_wrapped_container().status != 'running':
+            raise RuntimeError(f"Container exited before emitting logs satisfying predicate")
         time.sleep(interval)

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -83,7 +83,7 @@ def wait_for_logs(
     timeout: float = config.timeout,
     interval: float = 1,
     predicate_streams_and: bool = False,
-    raise_on_exit: bool = False
+    raise_on_exit: bool = False,
     #
 ) -> float:
     """
@@ -118,6 +118,6 @@ def wait_for_logs(
             return duration
         if duration > timeout:
             raise TimeoutError(f"Container did not emit logs satisfying predicate in {timeout:.3f} " "seconds")
-        if raise_on_exit and container.get_wrapped_container().status != 'running':
-            raise RuntimeError(f"Container exited before emitting logs satisfying predicate")
+        if raise_on_exit and container.get_wrapped_container().status != "running":
+            raise RuntimeError("Container exited before emitting logs satisfying predicate")
         time.sleep(interval)


### PR DESCRIPTION
Addresses my suggestion made in [issue 681](https://github.com/testcontainers/testcontainers-python/issues/681).

This PR adds a flag that checks is the status is not `running` and raises a `RuntimeError` to avoid waiting for logs after the container already has exited. The idea is to save wait time when there is a long startup time in case the container fails early.


```python
from testcontainers.core import container, waiting_utils

if __name__ == "__main__":
    waiting_utils.wait_for_logs(
        container.DockerContainer("flyway/flyway").start(),
        r"Successfully applied \d+ migrations to schema",
        timeout=10,
        raise_on_exit=True,
    )

# > RuntimeError(f"Container exited before emitting logs satisfying predicate")
# ( Raised almost immediately ) 
```