### PR TITLE
fix: Update the FastAPI install on genric module doctest samples

### DIFF
--- a/modules/generic/tests/samples/fastapi/Dockerfile
+++ b/modules/generic/tests/samples/fastapi/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 WORKDIR /app
 
-RUN pip install fastapi
+RUN pip install fastapi[standard]
 
 COPY ./app /app
 


### PR DESCRIPTION
### What was fixed
[FastAPI](https://github.com/fastapi/fastapi) now requires to provide the specific suit for the install, as a result one of the doctest (part of the `generic module`) got broken and its Dockerfile sample needed to be updated.