### PR TITLE
fix(keycloak): Add support for Keycloak version >=25

### DIFF
--- a/modules/keycloak/tests/test_keycloak.py
+++ b/modules/keycloak/tests/test_keycloak.py
@@ -2,7 +2,7 @@ import pytest
 from testcontainers.keycloak import KeycloakContainer
 
 
-@pytest.mark.parametrize("image_version", ["24.0.1", "18.0"])
+@pytest.mark.parametrize("image_version", ["25.0", "24.0.1", "18.0"])
 def test_docker_run_keycloak(image_version: str):
     with KeycloakContainer(f"quay.io/keycloak/keycloak:{image_version}") as keycloak_admin:
         assert keycloak_admin.get_client().users_count() == 1


### PR DESCRIPTION
Keycloak changed the health endpoint to a separate "management port" starting version 25.0.0 as can be read in the [changelogs](https://www.keycloak.org/docs/25.0.0/release_notes/#management-port-for-metrics-and-health-endpoints).

The keycloak module in testcontainers-python uses this endpoint for the readiness_probe. Currently compatibility with Keycloak >= 25 is broken.

This MR adds compatibility with Keycloak >= 25 by changing the readiness probe to do the following:
- Try the health endpoint on the management port
- If that gives a ConnectionError try the legacy health endpoint

An alternative approach would have been to create a separate LegacyKeycloakContainer class as has been done in other modules, however I think this unnecessarily complicates the user experience.

Additionally a public `get_management_url`  method has been added to give end-users convenient access to the new Keycloak management endpoint.
