### PR TITLE
fix(opensearch): add support for admin_password in >= 2.12

### DIFF
--- a/modules/opensearch/tests/test_opensearch.py
+++ b/modules/opensearch/tests/test_opensearch.py
@@ -1,5 +1,20 @@
 from testcontainers.opensearch import OpenSearchContainer
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_logging():
+    import logging
+    import warnings
+
+    warnings.filterwarnings("ignore")
+    logging.getLogger("opensearch").setLevel(logging.CRITICAL)
+
+    yield
+    warnings.resetwarnings()
+    logging.getLogger("opensearch").setLevel(logging.NOTSET)
+
 
 def test_docker_run_opensearch():
     with OpenSearchContainer() as opensearch:

--- a/modules/opensearch/tests/test_opensearch.py
+++ b/modules/opensearch/tests/test_opensearch.py
@@ -25,6 +25,14 @@ def test_docker_run_opensearch_v1_with_security():
         assert client.cluster.health()["status"] == "green"
 
 
+def test_docker_run_opensearch_v2_12():
+    with OpenSearchContainer(
+        image="opensearchproject/opensearch:2.12.0", initial_admin_password="Testing!#345"
+    ) as opensearch:
+        client = opensearch.get_client()
+        assert client.cluster.health()["status"] == "green"
+
+
 def test_search():
     with OpenSearchContainer() as opensearch:
         client = opensearch.get_client()


### PR DESCRIPTION
Opensearch has made an initial admin password mandatory since version 2.12 as can be read in the [changelogs](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.12.0.md).

The open search module in test containers-python does not pass in this additional flag and current compatibility with open search >= 2.12 is broken .

This MR adds compatibility with open search >= 2.12 by adding the inidial_admin_password flag to the docker environment 
