### PR TITLE
fix(tests): Missing artifacts (include-hidden-files)

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "coverage-artifact-${{ matrix.python-version}}"
+          include-hidden-files: true
           path: ".coverage.*"
           retention-days: 1
       - name: Run doctests


### PR DESCRIPTION
`upload-artifact` updated behavior: Hidden Files will be excluded by default 
https://github.com/actions/upload-artifact/issues/602

Need to include 
```yaml
include-hidden-files: true
```