### PR TITLE
fix(core): Typing in docker_client

### DIFF
--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -4,7 +4,7 @@ from logging import warning
 from os import environ
 from os.path import exists
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 import docker
 
@@ -21,7 +21,7 @@ class ConnectionMode(Enum):
 
         This is true for everything but bridge mode.
         """
-        if cast(str, self) == self.bridge_ip:
+        if self == self.bridge_ip:  # type: ignore[comparison-overlap]
             return False
         return True
 

--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -4,7 +4,7 @@ from logging import warning
 from os import environ
 from os.path import exists
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import docker
 
@@ -21,7 +21,7 @@ class ConnectionMode(Enum):
 
         This is true for everything but bridge mode.
         """
-        if self == self.bridge_ip:
+        if cast(str, self) == self.bridge_ip:
             return False
         return True
 
@@ -63,7 +63,7 @@ def get_user_overwritten_connection_mode() -> Optional[ConnectionMode]:
     """
     Return the user overwritten connection mode.
     """
-    connection_mode: str | None = environ.get("TESTCONTAINERS_CONNECTION_MODE")
+    connection_mode: Union[str, None] = environ.get("TESTCONTAINERS_CONNECTION_MODE")
     if connection_mode:
         try:
             return ConnectionMode(connection_mode)

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -180,17 +180,17 @@ class DockerClient:
         """
         container = self.get_container(container_id)
         network_name = self.network_name(container_id)
-        return cast(str, container["NetworkSettings"]["Networks"][network_name]["IPAddress"])
+        return str(container["NetworkSettings"]["Networks"][network_name]["IPAddress"])
 
     def network_name(self, container_id: str) -> str:
         """
         Get the name of the network this container runs on
         """
         container = self.get_container(container_id)
-        name = container["HostConfig"]["NetworkMode"]
+        name = str(container["HostConfig"]["NetworkMode"])
         if name == "default":
             return "bridge"
-        return cast(str, name)
+        return name
 
     def gateway_ip(self, container_id: str) -> str:
         """
@@ -198,7 +198,7 @@ class DockerClient:
         """
         container = self.get_container(container_id)
         network_name = self.network_name(container_id)
-        return cast(str, container["NetworkSettings"]["Networks"][network_name]["Gateway"])
+        return str(container["NetworkSettings"]["Networks"][network_name]["Gateway"])
 
     def get_connection_mode(self) -> ConnectionMode:
         """
@@ -235,7 +235,8 @@ class DockerClient:
             return "localhost"
         if "http" in url.scheme or "tcp" in url.scheme and url.hostname:
             # see https://github.com/testcontainers/testcontainers-python/issues/415
-            if url.hostname == "localnpipe" and utils.is_windows():
+            hostname = url.hostname
+            if not hostname or (hostname == "localnpipe" and utils.is_windows()):
                 return "localhost"
             return cast(str, url.hostname)
         if utils.inside_container() and ("unix" in url.scheme or "npipe" in url.scheme):

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -222,7 +222,7 @@ class DockerClient:
         # default for DinD
         return ConnectionMode.gateway_ip
 
-    def host(self) -> Optional[str]:
+    def host(self) -> str:
         """
         Get the hostname or ip address of the docker host.
         """


### PR DESCRIPTION
Supports: https://github.com/testcontainers/testcontainers-python/issues/305
Related : https://github.com/testcontainers/testcontainers-python/pull/691 https://github.com/testcontainers/testcontainers-python/pull/692 #700 

Based on #504, kudos @alexanderankin 

```
poetry run mypy --config-file pyproject.toml core/testcontainers/core/docker_client.py 
Success: no issues found in 1 source file
```

Old
```
                    Error Summary                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃ File Path                                 ┃ Errors ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ core/testcontainers/core/version.py       │ 12     │
│ core/testcontainers/core/docker_client.py │ 14     │
│ core/testcontainers/core/image.py         │ 17     │
│ core/testcontainers/core/waiting_utils.py │ 8      │
│ core/testcontainers/core/container.py     │ 20     │
│ core/tests/test_new_docker_api.py         │ 4      │
│ core/tests/test_docker_in_docker.py       │ 2      │
│ core/testcontainers/compose/compose.py    │ 22     │
│ core/testcontainers/compose/__init__.py   │ 2      │
│ core/tests/test_version.py                │ 2      │
│ core/tests/test_ryuk.py                   │ 2      │
│ core/tests/test_registry.py               │ 1      │
│ core/tests/test_image.py                  │ 3      │
│ core/tests/test_compose.py                │ 7      │
└───────────────────────────────────────────┴────────┘
Found 116 errors in 14 files.
```
New
```
                    Error Summary                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃ File Path                                 ┃ Errors ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ core/testcontainers/core/version.py       │ 12     │
│ core/testcontainers/core/network.py       │ 3      │
│ core/testcontainers/core/image.py         │ 17     │
│ core/testcontainers/core/waiting_utils.py │ 8      │
│ core/testcontainers/core/container.py     │ 19     │
│ core/tests/test_new_docker_api.py         │ 4      │
│ core/tests/test_docker_in_docker.py       │ 2      │
│ core/testcontainers/compose/compose.py    │ 22     │
│ core/testcontainers/compose/__init__.py   │ 2      │
│ core/tests/test_version.py                │ 2      │
│ core/tests/test_ryuk.py                   │ 2      │
│ core/tests/test_registry.py               │ 1      │
│ core/tests/test_image.py                  │ 3      │
│ core/tests/test_compose.py                │ 7      │
└───────────────────────────────────────────┴────────┘
Found 104 errors in 14 files.
```