### PR TITLE
fix: postgres use psql instead of logs

### DIFF
--- a/modules/postgres/testcontainers/postgres/__init__.py
+++ b/modules/postgres/testcontainers/postgres/__init__.py
@@ -11,13 +11,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import os
-from time import sleep
 from typing import Optional
 
-from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.utils import raise_for_deprecated_parameter
-from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
+from testcontainers.core.waiting_utils import wait_container_is_ready
 
 _UNSET = object()
 
@@ -92,6 +90,12 @@ class PostgresContainer(DbContainer):
     @wait_container_is_ready()
     def _connect(self) -> None:
         escaped_single_password = self.password.replace("'", "'\"'\"'")
-        result = self.exec(["sh", "-c", f"PGPASSWORD='{escaped_single_password}' psql --username {self.username} --dbname {self.dbname} --host 127.0.0.1 -c 'select version();'"])
+        result = self.exec(
+            [
+                "sh",
+                "-c",
+                f"PGPASSWORD='{escaped_single_password}' psql --username {self.username} --dbname {self.dbname} --host 127.0.0.1 -c 'select version();'",
+            ]
+        )
         if result.exit_code:
             raise ConnectionError("pg_isready is not ready yet")

--- a/modules/postgres/tests/test_postgres.py
+++ b/modules/postgres/tests/test_postgres.py
@@ -46,6 +46,16 @@ def test_docker_run_postgres_with_driver_pg8000():
             connection.execute(sqlalchemy.text("select 1=1"))
 
 
+def test_password_with_quotes():
+    postgres_container = PostgresContainer("postgres:9.5", password="'''''")
+    with postgres_container as postgres:
+        engine = sqlalchemy.create_engine(postgres.get_connection_url())
+        with engine.begin() as connection:
+            result = connection.execute(sqlalchemy.text("select version()"))
+            for row in result:
+                assert row[0].lower().startswith("postgresql 9.5")
+
+
 # This is a feature in the generic DbContainer class
 # but it can't be tested on its own
 # so is tested in various database modules:

--- a/modules/postgres/tests/test_postgres.py
+++ b/modules/postgres/tests/test_postgres.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
+import sqlalchemy
 
 from testcontainers.postgres import PostgresContainer
-import sqlalchemy
 
 
 # https://www.postgresql.org/support/versioning/


### PR DESCRIPTION
logs may be dependent on a particular locale

fixes: #703,  #695
