### PR TITLE
fix(core): Fix retrieval of the docker socket path when using rootless docker

### DIFF
--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -57,7 +57,7 @@ class DockerClient:
     """
 
     def __init__(self, **kwargs) -> None:
-        docker_host = get_docker_host()
+        docker_host = c.docker_host
 
         if docker_host:
             LOGGER.info(f"using host {docker_host}")
@@ -89,7 +89,7 @@ class DockerClient:
         **kwargs,
     ) -> Container:
         # If the user has specified a network, we'll assume the user knows best
-        if "network" not in kwargs and not get_docker_host():
+        if "network" not in kwargs and not c.docker_host:
             # Otherwise we'll try to find the docker host for dind usage.
             host_network = self.find_host_network()
             if host_network:
@@ -217,11 +217,6 @@ class DockerClient:
     def client_networks_create(self, name: str, param: dict):
         labels = create_labels("", param.get("labels"))
         return self.client.networks.create(name, **{**param, "labels": labels})
-
-
-def get_docker_host() -> Optional[str]:
-    return c.tc_properties_get_tc_host() or os.getenv("DOCKER_HOST")
-
 
 def get_docker_auth_config() -> Optional[str]:
     return c.docker_auth_config


### PR DESCRIPTION
Currently the docker socket path used by `ryuk` is not working for rootless docker. We need to manually set it through the `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` environment variable. 

When running locally the `DOCKER_HOST` is always the full URL to the docker socket, e.g. on linux/macos, it's the socket path prefixed with `unix://` and `npipe://` on windows. So we can easily extract the socket path using urllib parse:

```python
from urllib.parse import urlparse
docker_socket = urlparse(DOCKER_HOST).path
```

I improved the `TestcontainersConfiguration` so that the docker socket is inferred from the docker host when defined (and when the `RYUK_DOCKER_SOCKET` env is not explicitly defined)

The advantage of this approach is that it is automatically inferred from the `DOCKER_HOST` most of the time without the need for tedious manual configuration. And users can still explicitly define it for edge use-cases like before (e.g. when using docker over the network)

I moved `get_docker_host()` to make it part of the `TestcontainerConfig`, it was used at only 2 places, so it did not required many changes. And it makes sense to be part of the config

## Alternative solution

An alternatively solution has been proposed in https://github.com/testcontainers/testcontainers-python/issues/537. But it would rely on many uncertain and moving parts:
- the path to the docker socket in rootless docker to always look like this `"/run/user/{user_id}/docker.sock"` which might change in the future or be different depending on the OS and config
- being able to get the user ID somehow, on linux we can do it through the `UID` env variable, not sure if this works on macos, and it would probably not work on windows.

This solution could be implemented in `container.py`, e.g.:

```python
 def _create_instance(cls) -> "Reaper":
        logger.debug(f"Creating new Reaper for session: {SESSION_ID}")
        client = DockerClient()
        info = client.info()
        sec_opts = info.get('SecurityOptions') or tuple()
        is_rootless = any('rootless' in s for s in sec_opts)
        docker_socket = c.ryuk_docker_socket
        user_id = os.getenv('UID')
        if is_rootless and user_id:
            docker_socket = f"/run/user/{user_id}/docker.sock"
        Reaper._container = (
            DockerContainer(c.ryuk_image)
            .with_name(f"testcontainers-ryuk-{SESSION_ID}")
            .with_exposed_ports(8080)
            .with_volume_mapping(docker_socket, "/var/run/docker.sock", "rw")
            .with_kwargs(privileged=c.ryuk_privileged, auto_remove=True)
            .with_env("RYUK_RECONNECTION_TIMEOUT", c.ryuk_reconnection_timeout)
            .start()
        )
```

And would require to add `client.info()` in `docker_client.py`

```python
def info(self) -> Any:
        return self.client.info()
```

Fixes https://github.com/testcontainers/testcontainers-python/issues/537

@alexanderankin 