### PR TITLE
docs: Add an example for configuring a custom DockerContainer with exposed port and environment variale

### DIFF
--- a/core/README.rst
+++ b/core/README.rst
@@ -30,3 +30,18 @@ Using `DockerContainer` and `DockerImage` to create a container:
 
 The `DockerImage` class is used to build the image from the specified path and tag.
 The `DockerContainer` class is then used to create a container from the image.
+
+
+Creating a container with an exposed port and a custom environment variable:
+
+.. doctest::
+
+    >>> from testcontainers.core.container import DockerContainer
+    >>> from testcontainers.core.waiting_utils import wait_for_logs
+
+    >>> container = DockerContainer("stain/jena-fuseki:latest")
+    >>> container.with_exposed_ports(3030)
+    >>> container.with_env("ADMIN_PASSWORD", "password")
+    >>> container.start()
+    >>> delay = wait_for_logs(container, "Fuseki is available")
+    >>> container_url = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(3030)}"


### PR DESCRIPTION
Current examples for running a `DockerContainer` are all using `with DockerContainer` (3 examples out of 3). 

But this is not the right way when someone wants to add some custom configuration (expose a port, define an environment variable), which is quite a regular use-case.

Newcomers reading this docs might get confused and will need to go through the process of finding out how to do this properly outside of the docs (e.g. this guy here https://github.com/testcontainers/testcontainers-python/issues/709 )

So I have added a basic example, feel free to change the docker image/port for something else