### PR TITLE
fix(core): running testcontainer inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
-ARG PYTHON_VERSION
-FROM python:${version}-slim-bookworm
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
 
 WORKDIR /workspace
 RUN pip install --upgrade pip \
     && apt-get update \
-    && apt-get install -y \
-        freetds-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y freetds-dev \
+    && apt-get install -y make \
+    # no real need for keeping this image small at the moment
+    && :; # rm -rf /var/lib/apt/lists/*
 
-# install requirements we exported from poetry
-COPY build/requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+# install poetry
+RUN bash -c 'python -m venv /opt/poetry-venv && source $_/bin/activate && pip install poetry && ln -s $(which poetry) /usr/bin'
+
+# install dependencies with poetry
+COPY pyproject.toml .
+COPY poetry.lock .
+RUN poetry install --all-extras --with dev --no-root
 
 # copy project source
 COPY . .
+
+# install project with poetry
+RUN poetry install --all-extras --with dev

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ lint:  ## Lint all files in the project, which we also run in pre-commit
 	poetry run pre-commit run -a
 
 image: ## Make the docker image for dind tests
-	poetry export -f requirements.txt -o build/requirements.txt
 	docker build --build-arg PYTHON_VERSION=${PYTHON_VERSION} -t ${IMAGE} .
 
 DOCKER_RUN = docker run --rm -v /var/run/docker.sock:/var/run/docker.sock

--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -5,14 +5,15 @@ from typing import TYPE_CHECKING, Optional, Union
 import docker.errors
 from docker import version
 from docker.types import EndpointConfig
-from typing_extensions import Self
+from typing_extensions import Self, assert_never
 
+from testcontainers.core.config import ConnectionMode
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.exceptions import ContainerStartException
 from testcontainers.core.labels import LABEL_SESSION_ID, SESSION_ID
 from testcontainers.core.network import Network
-from testcontainers.core.utils import inside_container, is_arm, setup_logger
+from testcontainers.core.utils import is_arm, setup_logger
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 
 if TYPE_CHECKING:
@@ -128,33 +129,23 @@ class DockerContainer:
         self.stop()
 
     def get_container_host_ip(self) -> str:
-        # infer from docker host
-        host = self.get_docker_client().host()
-
-        # # check testcontainers itself runs inside docker container
-        # if inside_container() and not os.getenv("DOCKER_HOST") and not host.startswith("http://"):
-        #     # If newly spawned container's gateway IP address from the docker
-        #     # "bridge" network is equal to detected host address, we should use
-        #     # container IP address, otherwise fall back to detected host
-        #     # address. Even it's inside container, we need to double check,
-        #     # because docker host might be set to docker:dind, usually in CI/CD environment
-        #     gateway_ip = self.get_docker_client().gateway_ip(self._container.id)
-
-        #     if gateway_ip == host:
-        #         return self.get_docker_client().bridge_ip(self._container.id)
-        #     return gateway_ip
-        return host
+        connection_mode: ConnectionMode
+        connection_mode = self.get_docker_client().get_connection_mode()
+        if connection_mode == ConnectionMode.docker_host:
+            return self.get_docker_client().host()
+        elif connection_mode == ConnectionMode.gateway_ip:
+            return self.get_docker_client().gateway_ip(self._container.id)
+        elif connection_mode == ConnectionMode.bridge_ip:
+            return self.get_docker_client().bridge_ip(self._container.id)
+        else:
+            # ensure that we covered all possible connection_modes
+            assert_never(connection_mode)
 
     @wait_container_is_ready()
-    def get_exposed_port(self, port: int) -> str:
-        mapped_port = self.get_docker_client().port(self._container.id, port)
-        if inside_container():
-            gateway_ip = self.get_docker_client().gateway_ip(self._container.id)
-            host = self.get_docker_client().host()
-
-            if gateway_ip == host:
-                return port
-        return mapped_port
+    def get_exposed_port(self, port: int) -> int:
+        if self.get_docker_client().get_connection_mode().use_mapped_port:
+            return self.get_docker_client().port(self._container.id, port)
+        return port
 
     def with_command(self, command: str) -> Self:
         self._command = command

--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -1,5 +1,4 @@
 import contextlib
-from platform import system
 from socket import socket
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -131,11 +130,6 @@ class DockerContainer:
     def get_container_host_ip(self) -> str:
         # infer from docker host
         host = self.get_docker_client().host()
-        if not host:
-            return "localhost"
-        # see https://github.com/testcontainers/testcontainers-python/issues/415
-        if host == "localnpipe" and system() == "Windows":
-            return "localhost"
 
         # # check testcontainers itself runs inside docker container
         # if inside_container() and not os.getenv("DOCKER_HOST") and not host.startswith("http://"):

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -10,6 +10,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import contextlib
 import functools as ft
 import importlib.metadata
 import ipaddress
@@ -129,6 +130,15 @@ class DockerClient:
         """
         # If we're docker in docker running on a custom network, we need to inherit the
         # network settings, so we can access the resulting container.
+
+        # first to try to find the network the container runs in, if we can determine
+        container_id = utils.get_running_in_container_id()
+        if container_id:
+            with contextlib.suppress(Exception):
+                return self.network_name(container_id)
+
+        # if this results nothing, try to determine the network based on the
+        # docker_host
         try:
             host_ip = socket.gethostbyname(self.host())
             docker_host = ipaddress.IPv4Address(host_ip)

--- a/core/testcontainers/core/docker_client.py
+++ b/core/testcontainers/core/docker_client.py
@@ -25,13 +25,13 @@ from docker.models.containers import Container, ContainerCollection
 from docker.models.images import Image, ImageCollection
 from typing_extensions import ParamSpec
 
+from testcontainers.core import utils
 from testcontainers.core.auth import DockerAuthInfo, parse_docker_auth_config
 from testcontainers.core.config import ConnectionMode
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.labels import SESSION_ID, create_labels
-from testcontainers.core.utils import default_gateway_ip, inside_container, is_windows, setup_logger
 
-LOGGER = setup_logger(__name__)
+LOGGER = utils.setup_logger(__name__)
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -199,7 +199,7 @@ class DockerClient:
         if c.connection_mode_override:
             return c.connection_mode_override
         localhosts = {"localhost", "127.0.0.1", "::1"}
-        if not inside_container() or self.host() not in localhosts:
+        if not utils.inside_container() or self.host() not in localhosts:
             # if running not inside a container or with a non-local docker client,
             # connect ot the docker host per default
             return ConnectionMode.docker_host
@@ -225,11 +225,11 @@ class DockerClient:
             return "localhost"
         if "http" in url.scheme or "tcp" in url.scheme and url.hostname:
             # see https://github.com/testcontainers/testcontainers-python/issues/415
-            if host == "localnpipe" and is_windows():
+            if url.hostname == "localnpipe" and utils.is_windows():
                 return "localhost"
             return url.hostname
-        if inside_container() and ("unix" in url.scheme or "npipe" in url.scheme):
-            ip_address = default_gateway_ip()
+        if utils.inside_container() and ("unix" in url.scheme or "npipe" in url.scheme):
+            ip_address = utils.default_gateway_ip()
             if ip_address:
                 return ip_address
         return "localhost"

--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -3,7 +3,8 @@ import os
 import platform
 import subprocess
 import sys
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Final, Optional
 
 LINUX = "linux"
 MAC = "mac"
@@ -80,3 +81,20 @@ def raise_for_deprecated_parameter(kwargs: dict[Any, Any], name: str, replacemen
     if kwargs.pop(name, None):
         raise ValueError(f"Use `{replacement}` instead of `{name}`")
     return kwargs
+
+
+CGROUP_FILE: Final[Path] = Path("/proc/self/cgroup")
+
+
+def get_running_in_container_id() -> Optional[str]:
+    """
+    Get the id of the currently running container
+    """
+    if not CGROUP_FILE.is_file():
+        return None
+    cgroup = CGROUP_FILE.read_text()
+    for line in cgroup.splitlines(keepends=False):
+        path = line.rpartition(":")[2]
+        if path.startswith("/docker"):
+            return path.removeprefix("/docker/")
+    return None

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,6 +1,35 @@
+from pathlib import Path
+
 import pytest
 from typing import Callable
+import subprocess
 from testcontainers.core.container import DockerClient
+import sys
+
+PROJECT_DIR = Path(__file__).parent.parent.parent.resolve()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    Add configuration for custom pytest markers.
+    """
+    config.addinivalue_line(
+        "markers",
+        "inside_docker_check: test used to validate DinD/DooD are working as expected",
+    )
+
+
+@pytest.fixture(scope="session")
+def python_testcontainer_image() -> str:
+    """Build an image with test containers python for DinD and DooD tests"""
+    py_version = ".".join(map(str, sys.version_info[:2]))
+    image_name = f"testcontainers-python:{py_version}"
+    subprocess.run(
+        [*("docker", "build"), *("--build-arg", f"PYTHON_VERSION={py_version}"), *("-t", image_name), "."],
+        cwd=PROJECT_DIR,
+        check=True,
+    )
+    return image_name
 
 
 @pytest.fixture

--- a/core/tests/test_container.py
+++ b/core/tests/test_container.py
@@ -1,0 +1,77 @@
+import pytest
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.docker_client import DockerClient
+from testcontainers.core.config import ConnectionMode
+
+FAKE_ID = "ABC123"
+
+
+class FakeContainer:
+    @property
+    def id(self) -> str:
+        return FAKE_ID
+
+
+@pytest.fixture
+def container(monkeypatch: pytest.MonkeyPatch) -> DockerContainer:
+    """
+    Fake initialized container
+    """
+    client = DockerClient()
+    container = DockerContainer("foobar")
+    monkeypatch.setattr(container, "_docker", client)
+    monkeypatch.setattr(container, "_container", FakeContainer())
+
+    return container
+
+
+@pytest.mark.parametrize("mode", ["docker_host", "gateway_ip", "bridge_ip"])
+def test_get_container_host_ip(container: DockerContainer, monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    """
+    Depending on the connection mode the correct function is executed to the host_ip
+    """
+    connection_mode = ConnectionMode(mode)
+
+    def result_fake(result: str, require_container_id):
+        def fake_for_mode(*container_id: str):
+            if require_container_id:
+                assert len(container_id) == 1
+                assert container_id[0] == FAKE_ID
+            else:
+                assert len(container_id) == 0
+            return result
+
+        return fake_for_mode
+
+    client = container._docker
+
+    monkeypatch.setattr(client, "get_connection_mode", lambda: connection_mode)
+    monkeypatch.setattr(client, "gateway_ip", result_fake("gateway_ip", True))
+    monkeypatch.setattr(client, "bridge_ip", result_fake("bridge_ip", True))
+    monkeypatch.setattr(client, "host", result_fake("docker_host", False))
+
+    assert container.get_container_host_ip() == mode
+
+
+@pytest.mark.parametrize("mode", [ConnectionMode.gateway_ip, ConnectionMode.docker_host])
+def test_get_exposed_port_mapped(
+    container: DockerContainer, monkeypatch: pytest.MonkeyPatch, mode: ConnectionMode
+) -> None:
+    def fake_mapped(container_id: int, port: int) -> int:
+        assert container_id == FAKE_ID
+        assert port == 8080
+        return 45678
+
+    client = container._docker
+    monkeypatch.setattr(client, "port", fake_mapped)
+    monkeypatch.setattr(client, "get_connection_mode", lambda: mode)
+
+    assert container.get_exposed_port(8080) == 45678
+
+
+def test_get_exposed_port_original(container: DockerContainer, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = container._docker
+    monkeypatch.setattr(client, "get_connection_mode", lambda: ConnectionMode.bridge_ip)
+
+    assert container.get_exposed_port(8080) == 8080

--- a/core/tests/test_docker_client.py
+++ b/core/tests/test_docker_client.py
@@ -5,12 +5,14 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import docker
+import pytest
 
-from testcontainers.core.config import testcontainers_config as c
+from testcontainers.core.config import testcontainers_config as c, ConnectionMode
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.docker_client import DockerClient
 from testcontainers.core.auth import parse_docker_auth_config
 from testcontainers.core.image import DockerImage
+from testcontainers.core import utils
 
 from pytest import mark
 
@@ -116,3 +118,79 @@ def test_image_docker_client_kw():
         DockerImage(name="", path="", docker_client_kw=test_kwargs)
 
     mock_docker.from_env.assert_called_with(**test_kwargs)
+
+
+def test_host_prefer_host_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(c, "tc_host_override", "my_docker_host")
+    assert DockerClient().host() == "my_docker_host"
+
+
+@pytest.mark.parametrize(
+    "base_url, expected",
+    [
+        pytest.param("http://[-", "localhost", id="invalid_url"),
+        pytest.param("http+docker://localhost", "localhost", id="docker_socket"),
+        pytest.param("http://localnpipe", "localhost", id="docker_socket_windows"),
+        pytest.param("http://some_host", "some_host", id="other_host"),
+        pytest.param("unix://something", "1.2.3.4", id="inside_container_socket"),
+    ],
+)
+def test_host(monkeypatch: pytest.MonkeyPatch, base_url: str, expected: str) -> None:
+    client = DockerClient()
+    monkeypatch.setattr(client.client.api, "base_url", base_url)
+    monkeypatch.setattr(c, "tc_host_override", None)
+    # overwrite some utils in order to test all branches of host
+    monkeypatch.setattr(utils, "is_windows", lambda: True)
+    monkeypatch.setattr(utils, "inside_container", lambda: True)
+    monkeypatch.setattr(utils, "default_gateway_ip", lambda: "1.2.3.4")
+
+    assert client.host() == expected
+
+
+def test_get_connection_mode_overwritten(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(c, "connection_mode_override", ConnectionMode.gateway_ip)
+    assert DockerClient().get_connection_mode() == ConnectionMode.gateway_ip
+
+
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "::1"])
+def test_get_connection_mode_localhost_inside_container(monkeypatch: pytest.MonkeyPatch, host: str) -> None:
+    """
+    If docker host is localhost and we are inside a container prefer gateway_ip
+    """
+    client = DockerClient()
+    monkeypatch.setattr(c, "connection_mode_override", None)
+    monkeypatch.setattr(client, "host", lambda: host)
+    monkeypatch.setattr(client, "find_host_network", lambda: None)
+    monkeypatch.setattr(utils, "inside_container", lambda: True)
+    assert client.get_connection_mode() == ConnectionMode.gateway_ip
+
+
+def test_get_connection_mode_remote_docker_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Use docker_host inside container if remote docker host is given
+    """
+    client = DockerClient()
+    monkeypatch.setattr(c, "connection_mode_override", None)
+    monkeypatch.setattr(client, "host", lambda: "remote.docker.host")
+    monkeypatch.setattr(client, "find_host_network", lambda: None)
+    monkeypatch.setattr(utils, "inside_container", lambda: True)
+    assert client.get_connection_mode() == ConnectionMode.docker_host
+
+
+def test_get_connection_mode_dood(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    For docker out of docker (docker socket mount), we expect to be able
+    to find a host network.
+
+    In this case we should use the bridge ip as we can't expect
+    that either docker_host nor gateway_ip of the container are actually
+    reachable from within this network.
+
+    This is the case for instance if using Gitlab CIs `FF_NETWORK_PER_BUILD` flag
+    """
+    client = DockerClient()
+    monkeypatch.setattr(c, "connection_mode_override", None)
+    monkeypatch.setattr(client, "host", lambda: "localhost")
+    monkeypatch.setattr(client, "find_host_network", lambda: "new_bridge_network")
+    monkeypatch.setattr(utils, "inside_container", lambda: True)
+    assert client.get_connection_mode() == ConnectionMode.bridge_ip

--- a/core/tests/test_docker_in_docker.py
+++ b/core/tests/test_docker_in_docker.py
@@ -1,7 +1,19 @@
+import contextlib
+import os
 import time
 import socket
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from testcontainers.core import utils
+from testcontainers.core.config import testcontainers_config as tcc
+from testcontainers.core.labels import SESSION_ID
+from testcontainers.core.network import Network
 from testcontainers.core.container import DockerContainer
-from testcontainers.core.docker_client import DockerClient
+from testcontainers.core.docker_client import DockerClient, LOGGER
+from testcontainers.core.utils import inside_container
 from testcontainers.core.waiting_utils import wait_for_logs
 
 
@@ -85,3 +97,127 @@ def test_dind_inherits_network():
     not_really_dind.stop()
     not_really_dind.remove()
     custom_network.remove()
+
+
+@contextlib.contextmanager
+def print_surround_header(what: str, header_len: int = 80) -> None:
+    """
+    Helper to visually mark a block with headers
+    """
+    start = f"#   Beginning of {what}"
+    end = f"#   End of {what}"
+
+    print("\n")
+    print("#" * header_len)
+    print(start + " " * (header_len - len(start) - 1) + "#")
+    print("#" * header_len)
+    print("\n")
+
+    yield
+
+    print("\n")
+    print("#" * header_len)
+    print(end + " " * (header_len - len(end) - 1) + "#")
+    print("#" * header_len)
+    print("\n")
+
+
+EXPECTED_NETWORK_VAR: Final[str] = "TCC_EXPECTED_NETWORK"
+
+
+# see https://forums.docker.com/t/get-a-containers-full-id-from-inside-of-itself
+@pytest.mark.xfail(reason="Does not work in rootles docker i.e. github actions")
+@pytest.mark.inside_docker_check
+@pytest.mark.skipif(not os.environ.get(EXPECTED_NETWORK_VAR), reason="No expected network given")
+def test_find_host_network_in_dood() -> None:
+    """
+    Check that the correct host network is found for DooD
+    """
+    LOGGER.info(f"Running container id={utils.get_running_in_container_id()}")
+    LOGGER.info("Networks: ")
+    assert DockerClient().find_host_network() == os.environ[EXPECTED_NETWORK_VAR]
+
+
+@pytest.mark.skipif(not Path(tcc.ryuk_docker_socket).exists(), reason="No docker socket available")
+def test_dood(python_testcontainer_image: str) -> None:
+    """
+    Run tests marked as inside_docker_check inside docker out of docker
+    """
+
+    docker_sock = tcc.ryuk_docker_socket
+    with Network() as network:
+        with (
+            DockerContainer(
+                image=python_testcontainer_image,
+            )
+            .with_command("poetry run pytest -m inside_docker_check")
+            .with_volume_mapping(docker_sock, docker_sock, "rw")
+            # test also that the correct network was found
+            # but only do this if not already inside a container
+            # as there for some reason this doesn't work
+            .with_env(EXPECTED_NETWORK_VAR, "" if inside_container() else network.name)
+            .with_env("RYUK_RECONNECTION_TIMEOUT", "1s")
+            .with_network(network)
+        ) as container:
+            status = container.get_wrapped_container().wait()
+            stdout, stderr = container.get_logs()
+            # ensure ryuk removed the containers created inside container
+            # because they are bound our network the deletion of the network
+            # would fail otherwise
+            time.sleep(1.1)
+
+    # Show what was done inside test
+    with print_surround_header("test_dood results"):
+        print(stdout.decode("utf-8", errors="replace"))
+        print(stderr.decode("utf-8", errors="replace"))
+    assert status["StatusCode"] == 0
+
+
+def test_dind(python_testcontainer_image: str, tmp_path: Path) -> None:
+    """
+    Run selected tests in Docker in Docker
+    """
+    cert_dir = tmp_path / "certs"
+    dind_name = f"docker_{SESSION_ID}"
+    with Network() as network:
+        with (
+            DockerContainer(image="docker:dind", privileged=True)
+            .with_name(dind_name)
+            .with_volume_mapping(str(cert_dir), "/certs", "rw")
+            .with_env("DOCKER_TLS_CERTDIR", "/certs/docker")
+            .with_env("DOCKER_TLS_VERIFY", "1")
+            .with_network(network)
+            .with_network_aliases("docker")
+        ) as dind_container:
+            wait_for_logs(dind_container, "API listen on")
+            client_dir = cert_dir / "docker" / "client"
+            ca_file = client_dir / "ca.pem"
+            assert ca_file.is_file()
+            try:
+                with (
+                    DockerContainer(image=python_testcontainer_image)
+                    .with_command("poetry run pytest -m inside_docker_check")
+                    .with_volume_mapping(str(cert_dir), "/certs")
+                    # for some reason the docker client does not respect
+                    # DOCKER_TLS_CERTDIR and looks in /root/.docker instead
+                    .with_volume_mapping(str(client_dir), "/root/.docker")
+                    .with_env("DOCKER_TLS_CERTDIR", "/certs/docker/client")
+                    .with_env("DOCKER_TLS_VERIFY", "1")
+                    # docker port is 2376 for https, 2375 for http
+                    .with_env("DOCKER_HOST", "tcp://docker:2376")
+                    .with_network(network)
+                ) as test_container:
+                    status = test_container.get_wrapped_container().wait()
+                    stdout, stderr = test_container.get_logs()
+            finally:
+                # ensure the certs are deleted from inside the container
+                # as they might be owned by root it otherwise could lead to problems
+                # with pytest cleanup
+                dind_container.exec("rm -rf /certs/docker")
+                dind_container.exec("chmod -R a+rwX /certs")
+
+    # Show what was done inside test
+    with print_surround_header("test_dood results"):
+        print(stdout.decode("utf-8", errors="replace"))
+        print(stderr.decode("utf-8", errors="replace"))
+    assert status["StatusCode"] == 0

--- a/core/tests/test_ryuk.py
+++ b/core/tests/test_ryuk.py
@@ -11,11 +11,14 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
 
+@pytest.mark.inside_docker_check
 def test_wait_for_reaper(monkeypatch: MonkeyPatch):
     Reaper.delete_instance()
     monkeypatch.setattr(testcontainers_config, "ryuk_reconnection_timeout", "0.1s")
-    docker_client = DockerClient()
-    container = DockerContainer("hello-world").start()
+    container = DockerContainer("hello-world")
+    container.start()
+
+    docker_client = container.get_docker_client().client
 
     container_id = container.get_wrapped_container().short_id
     reaper_id = Reaper._container.get_wrapped_container().short_id
@@ -38,6 +41,7 @@ def test_wait_for_reaper(monkeypatch: MonkeyPatch):
     Reaper.delete_instance()
 
 
+@pytest.mark.inside_docker_check
 def test_container_without_ryuk(monkeypatch: MonkeyPatch):
     Reaper.delete_instance()
     monkeypatch.setattr(testcontainers_config, "ryuk_disabled", True)
@@ -46,6 +50,7 @@ def test_container_without_ryuk(monkeypatch: MonkeyPatch):
         assert Reaper._instance is None
 
 
+@pytest.mark.inside_docker_check
 def test_ryuk_is_reused_in_same_process():
     with DockerContainer("hello-world") as container:
         wait_for_logs(container, "Hello from Docker!")

--- a/modules/mysql/tests/test_mysql.py
+++ b/modules/mysql/tests/test_mysql.py
@@ -9,6 +9,7 @@ from testcontainers.core.utils import is_arm
 from testcontainers.mysql import MySqlContainer
 
 
+@pytest.mark.inside_docker_check
 def test_docker_run_mysql():
     config = MySqlContainer("mysql:8.3.0")
     with config as mysql:

--- a/modules/postgres/tests/test_postgres.py
+++ b/modules/postgres/tests/test_postgres.py
@@ -28,6 +28,7 @@ def test_docker_run_postgres(version: str, monkeypatch):
         assert status == 0
 
 
+@pytest.mark.inside_docker_check
 def test_docker_run_postgres_with_sqlalchemy():
     postgres_container = PostgresContainer("postgres:9.5")
     with postgres_container as postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ line-length = 120
 addopts = "--tb=short --strict-markers"
 log_cli = true
 log_cli_level = "INFO"
+markers = [
+    "inside_docker_check: mark test to be used to validate DinD/DooD is working as expected"
+]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
closes #475 

One step closer to solve #517

Replaces #622 

According to the [data collected](https://github.com/testcontainers/testcontainers-python/issues/475#issuecomment-2407250970) this should fix issues running testcontainers inside a container in almost all cases.

There is still an issue when running it within docker desktop, that is probably easily solved which checking for the existence of `host.docker.internal`.

But I have to recollect the data to ensure this, so this will be added at later point in time, as with with setting `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal` an easy workaround exists as well.