### PR TITLE
fix: update wait_for_logs to not throw on 'created', and an optimization

### DIFF
--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -110,8 +110,9 @@ def wait_for_logs(
     start = time.time()
     while True:
         duration = time.time() - start
-        stdout = container.get_logs()[0].decode()
-        stderr = container.get_logs()[1].decode()
+        stdout, stderr = container.get_logs()
+        stdout = stdout.decode()
+        stderr = stderr.decode()
         predicate_result = (
             predicate(stdout) or predicate(stderr)
             if predicate_streams_and is False

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -106,6 +106,7 @@ def wait_for_logs(
     """
     if isinstance(predicate, str):
         predicate = re.compile(predicate, re.MULTILINE).search
+    wrapped = container.get_wrapped_container()
     start = time.time()
     while True:
         duration = time.time() - start
@@ -121,6 +122,8 @@ def wait_for_logs(
             return duration
         if duration > timeout:
             raise TimeoutError(f"Container did not emit logs satisfying predicate in {timeout:.3f} " "seconds")
-        if raise_on_exit and container.get_wrapped_container().status not in _NOT_EXITED_STATUSES:
-            raise RuntimeError("Container exited before emitting logs satisfying predicate")
+        if raise_on_exit:
+            wrapped.reload()
+            if wrapped.status not in _NOT_EXITED_STATUSES:
+                raise RuntimeError("Container exited before emitting logs satisfying predicate")
         time.sleep(interval)

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -77,6 +77,9 @@ def wait_for(condition: Callable[..., bool]) -> bool:
     return condition()
 
 
+_NOT_EXITED_STATUSES = {"running", "created"}
+
+
 def wait_for_logs(
     container: "DockerContainer",
     predicate: Union[Callable, str],
@@ -118,6 +121,6 @@ def wait_for_logs(
             return duration
         if duration > timeout:
             raise TimeoutError(f"Container did not emit logs satisfying predicate in {timeout:.3f} " "seconds")
-        if raise_on_exit and container.get_wrapped_container().status != "running":
+        if raise_on_exit and container.get_wrapped_container().status not in _NOT_EXITED_STATUSES:
             raise RuntimeError("Container exited before emitting logs satisfying predicate")
         time.sleep(interval)


### PR DESCRIPTION
Attempt to fix another part of #715 , plus an optimization.

Based on #716 by @alexanderankin .