### PR TITLE
feat : Add support for depends_on functionality 

### DIFF
--- a/core/tests/test_container_dependencies.py
+++ b/core/tests/test_container_dependencies.py
@@ -1,0 +1,76 @@
+import pytest
+from docker.errors import APIError, ImageNotFound
+from testcontainers.core.container import DockerContainer
+
+
+def test_single_dependency_starts() -> None:
+    container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    dependency_container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    container.depends_on(dependency_container)
+
+    container.start()
+
+    assert dependency_container.wait_until_running(), "Dependency did not reach running state"
+    assert container.wait_until_running(), "Container did not reach running state"
+
+    container.stop()
+    dependency_container.stop()
+
+
+def test_multiple_dependencies_start() -> None:
+    container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    dependency1 = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    dependency2 = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    container.depends_on([dependency1, dependency2])
+
+    dependency1.start()
+    dependency2.start()
+    assert dependency1.wait_until_running(), "Dependency 1 did not reach running state"
+    assert dependency2.wait_until_running(), "Dependency 2 did not reach running state"
+
+    container.start()
+    assert container.wait_until_running(), "Container did not reach running state"
+
+    container.stop()
+    dependency1.stop()
+    dependency2.stop()
+
+
+def test_dependency_failure() -> None:
+    container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    failing_dependency = DockerContainer("nonexistent-image")
+    container.depends_on(failing_dependency)
+
+    with pytest.raises((APIError, ImageNotFound)):
+        container.start()
+
+    assert container._container is None
+
+
+def test_all_dependencies_fail() -> None:
+    container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    failing_dependency1 = DockerContainer("nonexistent-image1")
+    failing_dependency2 = DockerContainer("nonexistent-image2")
+    container.depends_on([failing_dependency1, failing_dependency2])
+
+    with pytest.raises((APIError, ImageNotFound)):
+        container.start()
+
+    assert container._container is None
+    assert failing_dependency1._container is None
+    assert failing_dependency2._container is None
+
+
+def test_dependency_cleanup_on_partial_failure() -> None:
+    container = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    dependency1 = DockerContainer("alpine:latest").with_command("tail -f /dev/null")
+    failing_dependency = DockerContainer("nonexistent-image3")
+
+    container.depends_on([dependency1, failing_dependency])
+
+    with pytest.raises(Exception):
+        container.start()
+
+    assert dependency1._container is None, "dependency1 was not cleaned up properly"
+    assert failing_dependency._container is None, "failing_dependency was not cleaned up properly"
+    assert container._container is None, "container was not cleaned up properly"


### PR DESCRIPTION
### Description:
This PR addresses issue #679 by introducing the depends_on functionality to DockerContainer, enhancing feature parity with the dependsOn functionality in TC-java by allowing containers to define dependencies. With this feature, a container can now specify dependencies on other containers, ensuring they will only start once all dependencies reach the running state.


### Changes

- Added a depends_on method to define dependencies between containers.

- Implemented _start_dependencies to manage recursive startup and ensure each dependency reaches the running state.

- Integrated exception handling for cleanup, ensuring that all dependencies are stopped if a failure occurs during the startup process.


### Sample Usage
```python
from testcontainers.core.container import DockerContainer

db_container = DockerContainer("mysql:latest").with_command("tail -f /dev/null")
app_container = DockerContainer("myapp:latest").with_command("tail -f /dev/null").depends_on(db_container)

app_container.start()

app_container.stop()
db_container.stop()

```

### Testing
### Added test cases to verify:
- Complete cleanup when all dependencies fail to start.

- Cleanup of all dependencies when some dependencies succeed, and others fail.

- Ensuring the main container does not start if any dependency fails.