### PR TITLE
chore: fix broken link in contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ You need to have the following tools available to you:
 
 ## Adding new containers
 
-We have an [issue template](.github/ISSUE_TEMPLATE/new-container.md) for adding new containers, please refer to that for more information.
+We have an [issue template](./ISSUE_TEMPLATE/new-container.md) for adding new containers, please refer to that for more information.
 Once you've talked to the maintainers (we do our best to reply!) then you can proceed with contributing the new container.
 
 > [!WARNING]


### PR DESCRIPTION
The previous link had '.github' twice in the path, as Github does not parse it as path from repo, but as path from current folder. Perhaps the contributing.md was previously at top level instead of .github folder.

The current link in main branch is: https://github.com/testcontainers/testcontainers-python/blob/main/.github/.github/ISSUE_TEMPLATE/new-container.md