### PR TITLE
fix: Vault health check

### DIFF
--- a/modules/vault/testcontainers/vault/__init__.py
+++ b/modules/vault/testcontainers/vault/__init__.py
@@ -12,6 +12,7 @@
 #    under the License.
 
 from http.client import HTTPException
+from urllib.error import URLError
 from urllib.request import urlopen
 
 from testcontainers.core.container import DockerContainer
@@ -61,7 +62,7 @@ class VaultContainer(DockerContainer):
         exposed_port = self.get_exposed_port(self.port)
         return f"http://{host_ip}:{exposed_port}"
 
-    @wait_container_is_ready(HTTPException)
+    @wait_container_is_ready(HTTPException, URLError)
     def _healthcheck(self) -> None:
         url = f"{self.get_connection_url()}/v1/sys/health"
         with urlopen(url) as res:


### PR DESCRIPTION

While migrating from Docker Desktop to Rancher Desktop on macOS, I encountered an issue where container port forwarding to the host machine was taking a long time. This delay caused the health check to fail with the following error:

```python
self = <urllib.request.HTTPHandler object at 0x108683a70>
http_class = <class 'http.client.HTTPConnection'>
req = <urllib.request.Request object at 0x1087788f0>, http_conn_args = {}
host = 'localhost:32771', h = <http.client.HTTPConnection object at 0x108683fb0>
headers = {'Connection': 'close', 'Host': 'localhost:32771', 'User-Agent': 'Python-urllib/3.12'}
 
    def do_open(self, http_class, req, **http_conn_args):
        """Return an HTTPResponse object for the request, using http_class.
        http_class must implement the HTTPConnection API from http.client.
        """
        host = req.host
        if not host:
            raise URLError('no host given')
        # will parse host:port
        h = http_class(host, timeout=req.timeout, **http_conn_args)
        h.set_debuglevel(self._debuglevel)
        headers = dict(req.unredirected_hdrs)
        headers.update({k: v for k, v in req.headers.items()
                        if k not in headers})
        # TODO: Redesign to handle persistent connections?
        # Currently, it uses HTTP/1.1 but doesn't support
        # persistent connections, which can cause blocking.
        # Ensures the connection closes after the single request.
        headers["Connection"] = "close"
        headers = {name.title(): val for name, val in headers.items()}
        if req._tunnel_host:
            tunnel_headers = {}
            proxy_auth_hdr = "Proxy-Authorization"
            if proxy_auth_hdr in headers:
                tunnel_headers[proxy_auth_hdr] = headers[proxy_auth_hdr]
                # Remove Proxy-Authorization from origin server request
                del headers[proxy_auth_hdr]
            h.set_tunnel(req._tunnel_host, headers=tunnel_headers)
        try:
            h.request(req.get_method(), req.selector, req.data, headers,
                      encode_chunked=req.has_header('Transfer-encoding'))
        except OSError as err:  # Timeout error
>           raise URLError(err)
E           urllib.error.URLError: <urlopen error [Errno 61] Connection refused>
 
../../../.asdf/installs/python/3.12.0/lib/python3.12/urllib/request.py:1347: URLError
```

This pull request resolves the issue.