### PR TITLE
feat(compose): support for setting profiles

### DIFF
--- a/core/testcontainers/compose/compose.py
+++ b/core/testcontainers/compose/compose.py
@@ -199,6 +199,8 @@ class DockerCompose:
         if self.compose_file_name:
             for file in self.compose_file_name:
                 docker_compose_cmd += ["-f", file]
+        if self.profiles:
+            docker_compose_cmd += [item for profile in self.profiles for item in ["--profile", profile]]
         if self.env_file:
             docker_compose_cmd += ["--env-file", self.env_file]
         return docker_compose_cmd
@@ -225,9 +227,6 @@ class DockerCompose:
         else:
             # we run in detached mode instead of blocking
             up_cmd.append("--detach")
-
-        if self.profiles:
-            up_cmd.extend([item for profile in self.profiles for item in ["--profile", profile]])
 
         if self.services:
             up_cmd.extend(self.services)

--- a/core/testcontainers/compose/compose.py
+++ b/core/testcontainers/compose/compose.py
@@ -171,6 +171,7 @@ class DockerCompose:
     env_file: Optional[str] = None
     services: Optional[list[str]] = None
     docker_command_path: Optional[str] = None
+    profiles: Optional[list[str]] = None
 
     def __post_init__(self):
         if isinstance(self.compose_file_name, str):
@@ -224,6 +225,9 @@ class DockerCompose:
         else:
             # we run in detached mode instead of blocking
             up_cmd.append("--detach")
+
+        if self.profiles:
+            up_cmd.extend([item for profile in self.profiles for item in ["--profile", profile]])
 
         if self.services:
             up_cmd.extend(self.services)

--- a/core/tests/compose_fixtures/profile_support/compose.yaml
+++ b/core/tests/compose_fixtures/profile_support/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  runs-always: &simple-service
+    image: alpine:latest
+    init: true
+    command:
+      - sh
+      - -c
+      - 'while true; do sleep 0.1 ; date -Ins; done'
+  runs-profile-a:
+    <<: *simple-service
+    profiles:
+      - profile-a
+  runs-profile-b:
+    <<: *simple-service
+    profiles:
+      - profile-b

--- a/core/tests/test_compose.py
+++ b/core/tests/test_compose.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 from re import split
 from time import sleep
-from typing import Union
+from typing import Union, Optional
 from urllib.request import urlopen, Request
 
 import pytest
@@ -369,7 +369,7 @@ def fetch(req: Union[Request, str]):
         ),
     ],
 )
-def test_compose_profile_support(profiles: list[str] | None, running: list[str], not_running: list[str]):
+def test_compose_profile_support(profiles: Optional[list[str]], running: list[str], not_running: list[str]):
     with DockerCompose(context=FIXTURES / "profile_support", profiles=profiles) as compose:
         for service in running:
             assert compose.get_container(service) is not None


### PR DESCRIPTION
# Change

Adds `profiles` support for docker compose.

# Context

I've had to use a workaround in a company project for compose profiles leading to multiple compose profile files. 
This should help by supporting profiles in compose which is a very handy feature when your service has some variety of ways to run (contextual, environmental, etc)

Without this, it's still possible to run profiles buy setting the `COMPOSE_PROFILES` env variable, but this is certainly cleaner and easier on test writing.


# Docker Docs

https://docs.docker.com/compose/how-tos/profiles/#assigning-profiles-to-services