### PR TITLE
Avoid hanging upon bad docker host connection

### DIFF
--- a/core/testcontainers/core/exceptions.py
+++ b/core/testcontainers/core/exceptions.py
@@ -16,6 +16,10 @@ class ContainerStartException(RuntimeError):
     pass
 
 
+class ContainerConnectException(RuntimeError):
+    pass
+
+
 class ContainerIsNotRunning(RuntimeError):
     pass
 


### PR DESCRIPTION
- Shorten the socket connection timeout
- Add a timeout on waiting for logs
- Add check for host and port values
- This _technically_ would already have timed out, though the default
timeout * 50 iterations is a long time to wait.
