### PR TITLE
fix(tests): replace dind-test direct docker usage with sdk

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 from typing import Callable
-import subprocess
 from testcontainers.core.container import DockerClient
 import sys
 
@@ -24,10 +23,12 @@ def python_testcontainer_image() -> str:
     """Build an image with test containers python for DinD and DooD tests"""
     py_version = ".".join(map(str, sys.version_info[:2]))
     image_name = f"testcontainers-python:{py_version}"
-    subprocess.run(
-        [*("docker", "build"), *("--build-arg", f"PYTHON_VERSION={py_version}"), *("-t", image_name), "."],
-        cwd=PROJECT_DIR,
-        check=True,
+    client = DockerClient()
+    client.build(
+        path=str(PROJECT_DIR),
+        tag=image_name,
+        rm=False,
+        buildargs={"PYTHON_VERSION": py_version},
     )
     return image_name
 


### PR DESCRIPTION
fix: #749

Replace using `subprocess.run` in the **dind** test with SDK to avoid the direct call to docker that enforces the developer to run _sudoless_ docker.