### PR TITLE
Do not setup log handlers to write to stderr

### DIFF
--- a/core/testcontainers/core/utils.py
+++ b/core/testcontainers/core/utils.py
@@ -14,9 +14,6 @@ WIN = "win"
 def setup_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
-    logger.addHandler(handler)
     return logger
 
 


### PR DESCRIPTION
By setting up a handler in the library, the library users do not have a good control on how/where to write the logs. Do not set a handler from the library.