### PR TITLE
fix: mongo start waiting forever for old mongo versions

### DIFF
--- a/modules/mongodb/testcontainers/mongodb/__init__.py
+++ b/modules/mongodb/testcontainers/mongodb/__init__.py
@@ -11,6 +11,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import os
+import re
 from typing import Optional
 
 from pymongo import MongoClient
@@ -77,7 +78,12 @@ class MongoDbContainer(DbContainer):
         )
 
     def _connect(self) -> None:
-        wait_for_logs(self, "Waiting for connections")
+        regex = re.compile(r"waiting for connections", re.MULTILINE | re.IGNORECASE)
+
+        def predicate(text: str) -> bool:
+            return regex.search(text) is not None
+
+        wait_for_logs(self, predicate)
 
     def get_connection_client(self) -> MongoClient:
         return MongoClient(self.get_connection_url())


### PR DESCRIPTION
Old versions of Mongo, like 3.6, log the message "waiting for connections [...]", with a lowercase 'w', while newer versions log the message with uppercase 'W'. This commit makes the log search when starting the container case insensitive.