### PR TITLE
fix(core): change with_command type to include list of strings

### DIFF
--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -155,7 +155,7 @@ class DockerContainer:
             return self.get_docker_client().port(self._container.id, port)
         return port
 
-    def with_command(self, command: str) -> Self:
+    def with_command(self, command: Union[str, list[str]]) -> Self:
         self._command = command
         return self
 


### PR DESCRIPTION
the `with_command` function can actually take an argument with type `list[str]`.