### PR TITLE
Use 'latest' tag for Qdrant module 

### DIFF
--- a/modules/qdrant/testcontainers/qdrant/__init__.py
+++ b/modules/qdrant/testcontainers/qdrant/__init__.py
@@ -39,7 +39,7 @@ class QdrantContainer(DbContainer):
 
     def __init__(
         self,
-        image: str = "qdrant/qdrant:v1.8.3",
+        image: str = "qdrant/qdrant:latest",
         rest_port: int = 6333,
         grpc_port: int = 6334,
         api_key: Optional[str] = None,


### PR DESCRIPTION
Newer versions of Qdrant include useful features like the [Batch Search API](https://qdrant.tech/documentation/concepts/search/#batch-search-api), which aren't available in older versions.

Instead of hardcoding a specific version, this PR sets the default image tag to `latest` so we automatically benefit from new features. While it's possible to override the image manually, having `latest` as the default keeps things simple, reduces boilerplate, and ensures we're testing against the most up-to-date Qdrant.
