### PR TITLE
fix(rabbitmq): correct pika pypi reference

### DIFF
--- a/modules/rabbitmq/testcontainers/rabbitmq/__init__.py
+++ b/modules/rabbitmq/testcontainers/rabbitmq/__init__.py
@@ -10,7 +10,7 @@ from testcontainers.core.waiting_utils import wait_container_is_ready
 class RabbitMqContainer(DockerContainer):
     """
     Test container for RabbitMQ. The example below spins up a RabbitMQ broker and uses the
-    `pika client library <(https://pypi.org/project/pika/)>`__ to establish a connection to the
+    `pika client library <https://pypi.org/project/pika/>`__ to establish a connection to the
     broker.
 
     Example:


### PR DESCRIPTION
## PR Summary
This small PR fixes the pika pypi reference in RabbitMqContainer class page. 
Relevant page: https://testcontainers-python.readthedocs.io/en/latest/modules/rabbitmq/README.html