### PR TITLE
fix(core): Make TC_POOLING_INTERVAL/sleep_time a float

### DIFF
--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -130,7 +130,7 @@ class TestcontainersConfiguration:
         return self.tc_properties.get("tc.host")
 
     @property
-    def timeout(self) -> int:
+    def timeout(self) -> float:
         return self.max_tries * self.sleep_time
 
     @property

--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -97,7 +97,7 @@ _WARNINGS = {"DOCKER_AUTH_CONFIG": "DOCKER_AUTH_CONFIG is experimental, see test
 @dataclass
 class TestcontainersConfiguration:
     max_tries: int = int(environ.get("TC_MAX_TRIES", "120"))
-    sleep_time: int = int(environ.get("TC_POOLING_INTERVAL", "1"))
+    sleep_time: float = float(environ.get("TC_POOLING_INTERVAL", "1"))
     ryuk_image: str = environ.get("RYUK_CONTAINER_IMAGE", "testcontainers/ryuk:0.8.1")
     ryuk_privileged: bool = get_bool_env("TESTCONTAINERS_RYUK_PRIVILEGED")
     ryuk_disabled: bool = get_bool_env("TESTCONTAINERS_RYUK_DISABLED")

--- a/core/testcontainers/core/waiting_utils.py
+++ b/core/testcontainers/core/waiting_utils.py
@@ -73,15 +73,15 @@ class WaitStrategy(ABC):
     """Base class for all wait strategies."""
 
     def __init__(self) -> None:
-        self._startup_timeout: int = config.timeout
+        self._startup_timeout: float = config.timeout
         self._poll_interval: float = config.sleep_time
 
     def with_startup_timeout(self, timeout: Union[int, timedelta]) -> "WaitStrategy":
         """Set the maximum time to wait for the container to be ready."""
         if isinstance(timeout, timedelta):
-            self._startup_timeout = int(timeout.total_seconds())
+            self._startup_timeout = float(int(timeout.total_seconds()))
         else:
-            self._startup_timeout = timeout
+            self._startup_timeout = float(timeout)
         return self
 
     def with_poll_interval(self, interval: Union[float, timedelta]) -> "WaitStrategy":


### PR DESCRIPTION
This config variable gets passed into `time.sleep`, which can work with ints and floats. Making this a float type allows polling intervals under a second, which can reduce startup times for containers that spin up very quickly.

I couldn't see any existing issue around this, and think it's probably only got a fairly small use case (but I do use it), so thought I'd throw up a PR as an easier way to just make the call on whether it's something you'd accept or not 🙇 