### PR TITLE
fix(postgres): Use with_bind_ports for postgres container

### DIFF
--- a/modules/postgres/testcontainers/postgres/__init__.py
+++ b/modules/postgres/testcontainers/postgres/__init__.py
@@ -63,7 +63,7 @@ class PostgresContainer(DbContainer):
         self.port = port
         self.driver = f"+{driver}" if driver else ""
 
-        self.with_exposed_ports(self.port)
+        self.with_bind_ports("5432/tcp", self.port)
 
     def _configure(self) -> None:
         self.with_env("POSTGRES_USER", self.username)

--- a/modules/postgres/tests/test_postgres.py
+++ b/modules/postgres/tests/test_postgres.py
@@ -151,3 +151,14 @@ def test_psycopg_versions():
         with engine.begin() as connection:
             result = connection.execute(sqlalchemy.text("SELECT 1 as test"))
             assert result.scalar() == 1
+
+
+def test_port_binding():
+    """Test that binding to a different port works as expected."""
+
+    postgres_container = PostgresContainer("postgres:16-alpine", port=12345)
+    with postgres_container as postgres:
+        engine = sqlalchemy.create_engine(postgres.get_connection_url())
+        with engine.begin() as connection:
+            result = connection.execute(sqlalchemy.text("SELECT 1 as test"))
+            assert result.scalar() == 1


### PR DESCRIPTION
with_exposed_ports for ports != 5432 breaks -- the internal port is always 5432, we're just binding to different host ports.