### PR TITLE
feat(azurite): Enhance connection string generation for network and local access

### DIFF
--- a/modules/azurite/tests/samples/network_container/Dockerfile
+++ b/modules/azurite/tests/samples/network_container/Dockerfile
@@ -1,0 +1,12 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+RUN pip install azure-storage-blob==12.19.0
+
+COPY ./netowrk_container.py netowrk_container.py
+EXPOSE 80
+# Define the command to run the application
+CMD ["python", "netowrk_container.py"]

--- a/modules/azurite/tests/samples/network_container/netowrk_container.py
+++ b/modules/azurite/tests/samples/network_container/netowrk_container.py
@@ -1,0 +1,27 @@
+from azure.storage.blob import BlobClient, BlobServiceClient
+import os
+
+
+def hello_from_external_container():
+    """
+    Entry point function for a custom Docker container to test connectivity
+    and operations with Azurite (or Azure Blob Storage).
+
+    This function is designed to run inside a separate container within the
+    same Docker network as an Azurite instance. It retrieves connection
+    details from environment variables and attempts to create a new
+    blob container on the connected storage account.
+    """
+    connection_string = os.environ["AZURE_CONNECTION_STRING"]
+    container_to_create = os.environ["AZURE_CONTAINER"]
+    blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+    # create dummy container just to make sure we can process the
+    try:
+        blob_service_client.create_container(name=container_to_create)
+        print("Azure Storage Container created.")
+    except Exception as e:
+        print(f"Something went wrong : {e}")
+
+
+if __name__ == "__main__":
+    hello_from_external_container()

--- a/modules/azurite/tests/test_azurite.py
+++ b/modules/azurite/tests/test_azurite.py
@@ -1,6 +1,24 @@
+import logging
+import time
+from pathlib import Path
+
 from azure.storage.blob import BlobServiceClient
 
-from testcontainers.azurite import AzuriteContainer
+from testcontainers.azurite import AzuriteContainer, ConnectionStringType
+
+from testcontainers.core.image import DockerImage
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.network import Network
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+logger = logging.getLogger(__name__)
+
+
+DOCKER_FILE_PATH = ".modules/azurite/tests/external_container_sample"
+IMAGE_TAG = "external_container:test"
+
+TEST_DIR = Path(__file__).parent
 
 
 def test_docker_run_azurite():
@@ -10,3 +28,49 @@ def test_docker_run_azurite():
         )
 
         blob_service_client.create_container("test-container")
+
+
+def test_docker_run_azurite_inter_container_communication():
+    """Tests inter-container communication between an Azurite container and a custom
+    application container within the same Docker network, while also verifying
+    local machine access to Azurite.
+
+    This test case validates the following:
+    1.  An Azurite container can be successfully started and configured with a
+        custom Docker network and a network alias.
+    2.  A custom application container can connect to the Azurite container
+        using a network-specific connection string (via its network alias)
+        within the shared Docker network.
+    3.  The Azurite container remains accessible from the local test machine
+        using a host-specific connection string.
+    4.  Operations performed by the custom container on Azurite (e.g., creating
+        a storage container) are visible and verifiable from the local machine.
+    """
+    container_name = "test-container"
+    with Network() as network:
+        with (
+            AzuriteContainer()
+            .with_network(network)
+            .with_network_aliases("azurite_server")
+            .with_exposed_ports(10000, 10000)
+            .with_exposed_ports(10001, 10001) as azurite_container
+        ):
+            network_connection_string = azurite_container.get_connection_string(ConnectionStringType.NETWORK)
+            local_connection_string = azurite_container.get_connection_string()
+            with DockerImage(path=TEST_DIR / "samples/network_container", tag=IMAGE_TAG) as image:
+                with (
+                    DockerContainer(image=str(image))
+                    .with_env("AZURE_CONNECTION_STRING", network_connection_string)
+                    .with_env("AZURE_CONTAINER", container_name)
+                    .with_network(network)
+                    .with_network_aliases("network_container")
+                    .with_exposed_ports(80, 80) as container
+                ):
+                    wait_for_logs(container, "Azure Storage Container created.")
+                blob_service_client = BlobServiceClient.from_connection_string(
+                    local_connection_string, api_version="2019-12-12"
+                )
+                # make sure the container was actually created
+                assert container_name in [
+                    blob_container["name"] for blob_container in blob_service_client.list_containers()
+                ]


### PR DESCRIPTION
**Resolves #851**

This Pull Request enhances the `AzuriteContainer` to provide more flexible and robust connection strings, specifically enabling seamless communication between Azurite and other containers within the same Docker network. It also clarifies access from the local host, addressing the need for distinct connection types in containerized testing environments.

---

### Key Changes

*   **Introduces `ConnectionStringType` enum:** This new enum allows specifying the intended access pattern when requesting an Azurite connection string:
    *   `NETWORK`: Optimized for inter-container communication, leveraging Docker network aliases for direct connectivity.
    *   `LOCALHOST`: Designed for access from the host machine, utilizing dynamically exposed ports and the Docker host IP.
*   **Refactored `get_connection_string`:** The main method now dispatches to the appropriate internal function based on the `ConnectionStringType` provided.
*   **Improved `get_external_connection_string`:** This method has been enhanced to intelligently prioritize network aliases for inter-container communication and provide a robust fallback to the Docker host IP for other scenarios.
*   **Comprehensive Unit Test:** A new test case, `test_azurite_inter_container_communication_with_network_string`, has been added to thoroughly validate both network-based and local host-based connection string functionality.
*   **Enhanced Docstrings:** All relevant methods within `AzuriteContainer` and the associated example application (`network_container.py`) have received updated and more detailed docstrings for improved clarity and usage guidance.

---

### Testing

To validate these functionalities, the new test case `test_azurite_inter_container_communication_with_network_string` was introduced. This test specifically verifies:
*   **Inter-container communication:** An external application container successfully connects to Azurite using the `NETWORK` connection string (via its network alias) and performs an operation (e.g., creates a blob container).
*   **Local host access verification:** The operation performed by the external container is then successfully verified from the local test machine using the `LOCALHOST` connection string, confirming data persistence and accessibility.

---

### Concerns and Questions

As this is my first contribution to this repository, I've aimed for comprehensive docstrings and clear code. I'm open to feedback on their level of detail, adherence to project conventions, or any other aspect of the implementation.

Please let me know if any further changes or clarifications are needed.
