### PR TITLE
fix(core): improper reading of .testcontainers.properties

### DIFF
--- a/core/testcontainers/core/config.py
+++ b/core/testcontainers/core/config.py
@@ -47,16 +47,6 @@ def get_docker_socket() -> str:
         return "/var/run/docker.sock"
 
 
-def get_bool_env(name: str) -> bool:
-    """
-    Get environment variable named `name` and convert it to bool.
-
-    Defaults to False.
-    """
-    value = environ.get(name, "")
-    return value.lower() in ENABLE_FLAGS
-
-
 TC_FILE = ".testcontainers.properties"
 TC_GLOBAL = Path.home() / TC_FILE
 
@@ -142,8 +132,8 @@ class TestcontainersConfiguration:
 
     @property
     def ryuk_privileged(self) -> bool:
-        if self._ryuk_privileged:
-            return self._ryuk_privileged
+        if self._ryuk_privileged is not None:
+            return bool(self._ryuk_privileged)
         self._ryuk_privileged = self._render_bool("TESTCONTAINERS_RYUK_PRIVILEGED", "ryuk.container.privileged")
         return self._ryuk_privileged
 
@@ -153,9 +143,8 @@ class TestcontainersConfiguration:
 
     @property
     def ryuk_disabled(self) -> bool:
-        if self._ryuk_disabled:
-            return self._ryuk_disabled
-
+        if self._ryuk_disabled is not None:
+            return bool(self._ryuk_disabled)
         self._ryuk_disabled = self._render_bool("TESTCONTAINERS_RYUK_DISABLED", "ryuk.disabled")
         return self._ryuk_disabled
 

--- a/core/tests/test_config.py
+++ b/core/tests/test_config.py
@@ -28,6 +28,68 @@ def test_read_tc_properties(monkeypatch: MonkeyPatch) -> None:
         assert config.tc_properties == {"tc.host": "some_value"}
 
 
+def test_set_tc_properties(monkeypatch: MonkeyPatch) -> None:
+    """
+    Ensure the configuration file variables can be read if no environment variable is set
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file = f"{tmpdirname}/{TC_FILE}"
+        with open(file, "w") as f:
+            f.write("ryuk.disabled=true\n")
+            f.write("ryuk.container.privileged=false\n")
+
+        monkeypatch.setattr("testcontainers.core.config.TC_GLOBAL", file)
+
+        config = TCC()
+
+        assert config.ryuk_disabled == True
+        assert config.ryuk_privileged == False
+
+
+def test_override_tc_properties_1(monkeypatch: MonkeyPatch) -> None:
+    """
+    Ensure that we can re-set the configuration variables programattically to override
+    testcontainers.properties
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file = f"{tmpdirname}/{TC_FILE}"
+        with open(file, "w") as f:
+            f.write("ryuk.disabled=true\n")
+            f.write("ryuk.container.privileged=false\n")
+
+        monkeypatch.setattr("testcontainers.core.config.TC_GLOBAL", file)
+
+        config = TCC()
+        config.ryuk_disabled = False
+        config.ryuk_privileged = True
+
+        assert config.ryuk_disabled == False
+        assert config.ryuk_privileged == True
+
+
+def test_override_tc_properties_2(monkeypatch: MonkeyPatch) -> None:
+    """
+    Ensure that we can override the testcontainers.properties with environment variables
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file = f"{tmpdirname}/{TC_FILE}"
+        with open(file, "w") as f:
+            f.write("ryuk.disabled=true\n")
+            f.write("ryuk.container.privileged=false\n")
+
+        monkeypatch.setattr("testcontainers.core.config.TC_GLOBAL", file)
+
+        import os
+
+        os.environ["TESTCONTAINERS_RYUK_DISABLED"] = "false"
+        os.environ["TESTCONTAINERS_RYUK_PRIVILEGED"] = "true"
+
+        config = TCC()
+
+        assert config.ryuk_disabled == False
+        assert config.ryuk_privileged == True
+
+
 @mark.parametrize("docker_auth_config_env", ["key=value", ""])
 @mark.parametrize("warning_dict", [{}, {"key": "value"}, {"DOCKER_AUTH_CONFIG": "TEST"}])
 @mark.parametrize("warning_dict_post", [{}, {"key": "value"}, {"DOCKER_AUTH_CONFIG": "TEST"}])


### PR DESCRIPTION
fix #864 

The environment variables were not overridden from the .testcontainers.properties file for ryuk variables. This causes the properties file to never actually be used. This commit detects the environment variable, and if unspecified falls back to the properties file, and if not specified, defaults to false