### PR TITLE
fix(core): Added 'compose' in compose_command_property

### DIFF
--- a/core/testcontainers/compose/compose.py
+++ b/core/testcontainers/compose/compose.py
@@ -247,7 +247,7 @@ class DockerCompose:
 
     @cached_property
     def compose_command_property(self) -> list[str]:
-        docker_compose_cmd = [self.docker_command_path] if self.docker_command_path else ["docker", "compose"]
+        docker_compose_cmd = [self.docker_command_path, "compose"] if self.docker_command_path else ["docker", "compose"]
         if self.compose_file_name:
             for file in self.compose_file_name:
                 docker_compose_cmd += ["-f", file]


### PR DESCRIPTION
If docker_command_path is specified, 'compose' is not appended, which causes all of DockerCompose to not work. This issue was found when attempting to use podman.