### PR TITLE
fix: add PEP 561 py.typed markers for type checker support

### DIFF
--- a/core/testcontainers/py.typed
+++ b/core/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/arangodb/testcontainers/py.typed
+++ b/modules/arangodb/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/aws/testcontainers/py.typed
+++ b/modules/aws/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/azurite/testcontainers/py.typed
+++ b/modules/azurite/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/cassandra/testcontainers/py.typed
+++ b/modules/cassandra/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/chroma/testcontainers/py.typed
+++ b/modules/chroma/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/clickhouse/testcontainers/py.typed
+++ b/modules/clickhouse/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/cockroachdb/testcontainers/py.typed
+++ b/modules/cockroachdb/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/cosmosdb/testcontainers/py.typed
+++ b/modules/cosmosdb/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/db2/testcontainers/py.typed
+++ b/modules/db2/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/elasticsearch/testcontainers/py.typed
+++ b/modules/elasticsearch/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/generic/testcontainers/py.typed
+++ b/modules/generic/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/google/testcontainers/py.typed
+++ b/modules/google/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/influxdb/testcontainers/py.typed
+++ b/modules/influxdb/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/k3s/testcontainers/py.typed
+++ b/modules/k3s/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/kafka/testcontainers/py.typed
+++ b/modules/kafka/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/keycloak/testcontainers/py.typed
+++ b/modules/keycloak/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/localstack/testcontainers/py.typed
+++ b/modules/localstack/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/mailpit/testcontainers/py.typed
+++ b/modules/mailpit/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/memcached/testcontainers/py.typed
+++ b/modules/memcached/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/milvus/testcontainers/py.typed
+++ b/modules/milvus/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/minio/testcontainers/py.typed
+++ b/modules/minio/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/mongodb/testcontainers/py.typed
+++ b/modules/mongodb/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/mqtt/testcontainers/py.typed
+++ b/modules/mqtt/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/mssql/testcontainers/py.typed
+++ b/modules/mssql/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/mysql/testcontainers/py.typed
+++ b/modules/mysql/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/nats/testcontainers/py.typed
+++ b/modules/nats/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/neo4j/testcontainers/py.typed
+++ b/modules/neo4j/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/nginx/testcontainers/py.typed
+++ b/modules/nginx/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/ollama/testcontainers/py.typed
+++ b/modules/ollama/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/openfga/testcontainers/py.typed
+++ b/modules/openfga/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/opensearch/testcontainers/py.typed
+++ b/modules/opensearch/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/oracle-free/testcontainers/py.typed
+++ b/modules/oracle-free/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/postgres/testcontainers/py.typed
+++ b/modules/postgres/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/qdrant/testcontainers/py.typed
+++ b/modules/qdrant/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/rabbitmq/testcontainers/py.typed
+++ b/modules/rabbitmq/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/redis/testcontainers/py.typed
+++ b/modules/redis/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/registry/testcontainers/py.typed
+++ b/modules/registry/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/scylla/testcontainers/py.typed
+++ b/modules/scylla/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/selenium/testcontainers/py.typed
+++ b/modules/selenium/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/sftp/testcontainers/py.typed
+++ b/modules/sftp/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/test_module_import/testcontainers/py.typed
+++ b/modules/test_module_import/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/trino/testcontainers/py.typed
+++ b/modules/trino/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/vault/testcontainers/py.typed
+++ b/modules/vault/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/modules/weaviate/testcontainers/py.typed
+++ b/modules/weaviate/testcontainers/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
+# Ensure PEP 561 typing marker files are included in distributions
+include = ["**/py.typed"]
 # testcontainers-core is a proper package dependency - only modules needed here
 packages = [
     { include = "testcontainers", from = "core" },


### PR DESCRIPTION
  Add py.typed marker files to core and all module packages to indicate
  type information is available. This enables type checkers like Pyright
  and mypy to recognize and validate type hints in testcontainers packages.

  Resolves "Stub file not found" errors when running type checkers on
  code that imports testcontainers modules.