### PR TITLE
fix(sftp): Avoid using wait_for_logs in module.

### DIFF
--- a/modules/sftp/testcontainers/sftp/__init__.py
+++ b/modules/sftp/testcontainers/sftp/__init__.py
@@ -265,9 +265,9 @@ class SFTPContainer(DockerContainer):
         self.with_exposed_ports(self.port)
 
     def start(self) -> Self:
-        super().start()
         strategy = LogMessageWaitStrategy(f".*Server listening on 0.0.0.0 port {self.port}.*")
         self.waiting_for(strategy)
+        super().start()
         return self
 
     def get_exposed_sftp_port(self) -> int:


### PR DESCRIPTION
This fixes bug #994.