### PR TITLE
fix(core): close Reaper socket at interpreter exit to prevent ResourceWarning

### DIFF
--- a/core/testcontainers/core/container.py
+++ b/core/testcontainers/core/container.py
@@ -1,3 +1,4 @@
+import atexit
 import contextlib
 import io
 import pathlib
@@ -476,5 +477,6 @@ class Reaper:
         rs.send(f"label={LABEL_SESSION_ID}={SESSION_ID}\r\n".encode())
 
         Reaper._instance = Reaper()
+        atexit.register(Reaper.delete_instance)
 
         return Reaper._instance


### PR DESCRIPTION
The Ryuk keep-alive socket stored in `Reaper._socket` was never explicitly
closed, so CPython's GC finalized it during interpreter shutdown and emitted
a ResourceWarning ("unclosed <socket.socket ...>") that is impossible to
suppress via warnings filters because it fires after pytest exits.

```
================================================ slowest 10 durations =================================================
12.25s setup    tests/test_integration.py::TestIntegration::test_ensure_tables_creates_schema_if_not_exists
0.26s call     tests/test_integration.py::TestIntegration::test_ensure_tables_creates_schema_if_not_exists
0.25s teardown tests/test_integration.py::TestIntegration::test_ensure_tables_creates_schema_if_not_exists
0.21s call     tests/test_state.py::test_acquire_lock_max_retries_exceeded

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================================== 23 passed, 1 warning in 13.04s ============================================
Exception ignored in: <socket.socket fd=22, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 55812)>
ResourceWarning: unclosed <socket.socket fd=22, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 55812)>
```

Registering `Reaper.delete_instance` with `atexit` ensures the socket is closed
cleanly before the GC sweep, eliminating the warning without changing the
socket's lifetime during the test session.
