### PR TITLE
fix(cosmosdb): replace distutils.strtobool removed in Python 3.12

### DIFF
--- a/modules/cosmosdb/testcontainers/cosmosdb/_emulator.py
+++ b/modules/cosmosdb/testcontainers/cosmosdb/_emulator.py
@@ -2,7 +2,6 @@ import os
 import socket
 import ssl
 from collections.abc import Iterable
-from distutils.util import strtobool
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
@@ -16,6 +15,7 @@ from . import _grab as grab
 __all__ = ["CosmosDBEmulatorContainer"]
 
 EMULATOR_PORT = 8081
+_ENV_TRUTHY = {"true", "1", "yes"}
 
 
 class CosmosDBEmulatorContainer(DockerContainer):
@@ -32,12 +32,12 @@ class CosmosDBEmulatorContainer(DockerContainer):
             "AZURE_COSMOS_EMULATOR_IMAGE", "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest"
         ),
         partition_count: int = os.getenv("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", None),
-        enable_data_persistence: bool = strtobool(os.getenv("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "false")),
+        enable_data_persistence: bool = os.getenv("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "false").strip().lower() in _ENV_TRUTHY,
         key: str = os.getenv(
             "AZURE_COSMOS_EMULATOR_KEY",
             "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
         ),
-        bind_ports: bool = strtobool(os.getenv("AZURE_COSMOS_EMULATOR_BIND_PORTS", "true")),
+        bind_ports: bool = os.getenv("AZURE_COSMOS_EMULATOR_BIND_PORTS", "true").strip().lower() in _ENV_TRUTHY,
         endpoint_ports: Iterable[int] = [],
         **other_kwargs,
     ):


### PR DESCRIPTION
## Problem

The `cosmosdb` module imports `distutils.util.strtobool` in `_emulator.py`. The `distutils` module was deprecated in Python 3.10 ([PEP 632](https://peps.python.org/pep-0632/)) and **removed in Python 3.12**. This causes an `ImportError` when using the CosmosDB module on Python 3.12+:

```
ModuleNotFoundError: No module named 'distutils'
```
