### PR TITLE
fix(k3s): use with_tmpfs_mount to avoid duplicate tmpfs kwarg

### DIFF
--- a/modules/k3s/testcontainers/k3s/__init__.py
+++ b/modules/k3s/testcontainers/k3s/__init__.py
@@ -44,7 +44,9 @@ class K3SContainer(DockerContainer):
         self.with_exposed_ports(self.KUBE_SECURE_PORT, self.RANCHER_WEBHOOK_PORT)
         self.with_env("K3S_URL", f"https://{self.get_container_host_ip()}:{self.KUBE_SECURE_PORT}")
         self.with_command("server --disable traefik --tls-san=" + self.get_container_host_ip())
-        self.with_kwargs(privileged=True, tmpfs={"/run": "", "/var/run": ""})
+        self.with_kwargs(privileged=True)
+        self.with_tmpfs_mount("/run")
+        self.with_tmpfs_mount("/var/run")
         if enable_cgroup_mount:
             self.with_volume_mapping("/sys/fs/cgroup", "/sys/fs/cgroup", "rw")
         else:


### PR DESCRIPTION
## Problem

`K3SContainer.__init__` configures tmpfs mounts via `with_kwargs`:

```python
self.with_kwargs(privileged=True, tmpfs={"/run": "", "/var/run": ""})
```

Since #978, `DockerContainer.start()` also passes `tmpfs=self.tmpfs` explicitly to `docker_client.create()`, while still spreading `**self._kwargs`. This causes a duplicate-keyword error on every K3S container start:

```
TypeError: docker.models.containers.ContainerCollection.run() got multiple values for keyword argument 'tmpfs'
```

CI evidence: every `test (3.10|3.13|3.14, k3s)` job fails with this error.

## Fix

Migrate to the dedicated `with_tmpfs_mount()` API introduced in #978, leaving only `privileged=True` in `with_kwargs`.

## Verification

`uv run pytest -q modules/k3s/tests/test_k3s.py` no longer raises the `TypeError` (container starts successfully; remaining test progression depends on CI environment as before).