### PR TITLE
test(milvus): cast exposed_port to str for substring assert

### DIFF
--- a/modules/milvus/testcontainers/milvus/__init__.py
+++ b/modules/milvus/testcontainers/milvus/__init__.py
@@ -32,7 +32,7 @@ class MilvusContainer(DockerContainer):
 
             >>> from testcontainers.milvus import MilvusContainer
             >>> with MilvusContainer("milvusdb/milvus:v2.4.4") as milvus_container:
-            ...     milvus_container.get_exposed_port(milvus_container.port) in milvus_container.get_connection_url()
+            ...     str(milvus_container.get_exposed_port(milvus_container.port)) in milvus_container.get_connection_url()
             True
     """
 

--- a/modules/milvus/tests/test_milvus.py
+++ b/modules/milvus/tests/test_milvus.py
@@ -21,7 +21,7 @@ def test_run_milvus_success(version: str):
         exposed_port = milvus_container.get_exposed_port(milvus_container.port)
         url = milvus_container.get_connection_url()
 
-    assert url and exposed_port in url
+    assert url and str(exposed_port) in url
 
 
 @pytest.mark.parametrize("version", VERSIONS)


### PR DESCRIPTION
## Problem

`test_run_milvus_success` asserts:

```python
assert url and exposed_port in url
```

`get_exposed_port()` returns `int`, so the `in` check against a string `url` raises:

```
TypeError: 'in <string>' requires string as left operand, not int
```

CI evidence: `test (3.10|3.13|3.14, milvus)` jobs fail this assertion for both `v2.4.0` and `v2.4.4`.

## Fix

Cast `exposed_port` to `str` before the substring check.