### PR TITLE
chore(ci): skip scylla module tests on Python 3.14

### DIFF
--- a/.github/workflows/ci-community.yml
+++ b/.github/workflows/ci-community.yml
@@ -50,6 +50,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.13", "3.14"]
         module: ${{ fromJSON(needs.track-modules.outputs.changed_modules) }}
+        exclude:
+          # cassandra-driver has no Python 3.14 support
+          # (see `python_version < '3.14'` markers in pyproject.toml).
+          - python-version: "3.14"
+            module: scylla
     steps:
       - name: Checkout contents
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`test (3.14, scylla)` fails with:

```
ModuleNotFoundError: No module named 'cassandra'
```

`cassandra-driver` is gated by `python_version < '3.14'` in two places in `pyproject.toml`:

```toml
scylla = ["cassandra-driver>=3; python_version < '3.14'"]
...
test = ["cassandra-driver>=3; python_version < '3.14'", ...]
```

So on Python 3.14 the driver isn't installed, but the matrix still attempts to run scylla tests, which import `cassandra.cluster` at runtime inside `ScyllaContainer._connect()`.

## Fix

Exclude the `(3.14, scylla)` combination from the test matrix to reflect the existing dependency constraint.

## Note

The `cassandra` module has the same dependency constraint and may need the same treatment, but is left out of this PR since CI does not currently flag it (likely not in `changed_modules` for recent PRs).