### PR TITLE
test(rabbitmq): declare exchange and queue as durable

### DIFF
--- a/modules/rabbitmq/tests/test_rabbitmq.py
+++ b/modules/rabbitmq/tests/test_rabbitmq.py
@@ -43,8 +43,8 @@ def test_docker_run_rabbitmq(
 
         # create exchange and queue:
         channel = connection.channel()
-        channel.exchange_declare(exchange=EXCHANGE, exchange_type="topic")
-        channel.queue_declare(QUEUE, arguments={})
+        channel.exchange_declare(exchange=EXCHANGE, exchange_type="topic", durable=True)
+        channel.queue_declare(QUEUE, durable=True, arguments={})
         channel.queue_bind(QUEUE, EXCHANGE, ROUTING_KEY)
 
         # publish message:


### PR DESCRIPTION
## Problem

`test_docker_run_rabbitmq` fails on all 4 parametrized cases against `rabbitmq:latest` (currently 4.x):

```
pika.exceptions.ConnectionClosedByBroker: (541, 'INTERNAL_ERROR -
Feature `transient_nonexcl_queues` is deprecated.
By default, this feature is not permitted anymore.')
```

The earlier `IncompatibleProtocolError` / `StreamLostError` lines in CI logs were a downstream symptom of the broker dropping the connection after the rejected queue declaration.

## Fix

Declare both the exchange and the queue as `durable=True`. RabbitMQ 4.x disallows transient non-exclusive queues by default; durable is the supported replacement and is appropriate for an integration test that publishes/consumes a single message.

## Verification

`uv run pytest -q modules/rabbitmq/tests/test_rabbitmq.py` — 4 passed locally against `rabbitmq:latest`.