### PR TITLE
fix(core): make is_podman respect resolved docker host

### DIFF
--- a/src/testcontainers/core/docker_client.py
+++ b/src/testcontainers/core/docker_client.py
@@ -535,9 +535,20 @@ def is_podman() -> bool:
     ``pytest.mark.skipif`` decorators.
     """
     try:
-        # Use docker.from_env() directly rather than DockerClient() so we avoid
-        # the constructor's side effects (DOCKER_HOST mutation, registry login).
-        version = docker.from_env().version()
+        # Build the client directly rather than via DockerClient() so we avoid
+        # the constructor's side effects (registry login). We still resolve the
+        # host the same way DockerClient does so that hosts coming from the
+        # docker context (and SSH connections) are detected correctly.
+        docker_host = get_docker_host()
+        if docker_host:
+            client_kwargs: dict[str, Any] = {"base_url": docker_host}
+            if docker_host.startswith("ssh://"):
+                # Mirror DockerClient: use the shell SSH client to avoid paramiko
+                # failures under pytest stdin capture.
+                client_kwargs["use_ssh_client"] = True
+            version = docker.DockerClient(**client_kwargs).version()
+        else:
+            version = docker.from_env().version()
     except Exception as e:
         LOGGER.debug(f"is_podman: failed to query daemon version: {e}")
         return False

--- a/tests/core/test_docker_client.py
+++ b/tests/core/test_docker_client.py
@@ -373,6 +373,9 @@ def test_is_podman(monkeypatch: pytest.MonkeyPatch, version: object, expected: b
     from testcontainers.core import docker_client as dc
 
     dc.is_podman.cache_clear()
+    # Force the no-host branch so the test is deterministic regardless of the
+    # docker context configured on the machine running it.
+    monkeypatch.setattr("testcontainers.core.docker_client.get_docker_host", lambda: None)
     mock_client = MagicMock()
     if isinstance(version, Exception):
         monkeypatch.setattr("testcontainers.core.docker_client.docker.from_env", MagicMock(side_effect=version))
@@ -385,6 +388,28 @@ def test_is_podman(monkeypatch: pytest.MonkeyPatch, version: object, expected: b
         assert dc.is_podman() is expected
         if not isinstance(version, Exception):
             assert mock_client.version.call_count == 1
+    finally:
+        dc.is_podman.cache_clear()
+
+
+def test_is_podman_uses_resolved_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a host is resolved (e.g. from the docker context), is_podman must
+    query that host rather than falling back to docker.from_env defaults."""
+    from testcontainers.core import docker_client as dc
+
+    dc.is_podman.cache_clear()
+    monkeypatch.setattr("testcontainers.core.docker_client.get_docker_host", lambda: "ssh://root@remote-podman")
+    mock_client = MagicMock()
+    mock_client.version.return_value = {"Platform": {"Name": "Podman Engine"}}
+    mock_docker_client = MagicMock(return_value=mock_client)
+    monkeypatch.setattr("testcontainers.core.docker_client.docker.DockerClient", mock_docker_client)
+    monkeypatch.setattr(
+        "testcontainers.core.docker_client.docker.from_env",
+        MagicMock(side_effect=AssertionError("should not call from_env when host resolved")),
+    )
+    try:
+        assert dc.is_podman() is True
+        mock_docker_client.assert_called_once_with(base_url="ssh://root@remote-podman", use_ssh_client=True)
     finally:
         dc.is_podman.cache_clear()
 


### PR DESCRIPTION
Follow-up to #1026 (auto-detect DOCKER_HOST from the current docker context).

## Problem

`is_podman()` used a bare `docker.from_env()`, which ignores the host resolved by `get_docker_host()` and never sets `use_ssh_client` for SSH hosts.

When a remote daemon is configured via a docker context (and `DOCKER_HOST` is not exported), `is_podman()` hit the local default socket, failed, and silently returned `False`. Two consequences:

- Podman over a docker context was never detected, so Podman-specific normalisation (e.g. in the port tests) was skipped.
- SSH-based remote daemons could not be queried at all (paramiko also fails under pytest stdin capture, which is why `DockerClient` passes `use_ssh_client=True`).

## Fix

`is_podman()` now resolves the host the same way `DockerClient` does: it builds a client with the resolved `base_url` (and `use_ssh_client=True` for `ssh://`), and only falls back to `docker.from_env()` when no host is resolved.

## Tests

- Pinned `get_docker_host` to `None` in the existing `test_is_podman` parametrisation so it is deterministic regardless of the docker context configured on the machine running it (it was silently passing only when no context was set).
- Added `test_is_podman_uses_resolved_host` covering the resolved-host SSH branch.

## Verified manually

Ran `tests/core/test_core_ports.py` and `tests/core/test_docker_client.py` against two remote backends over SSH:

| Context | Backend | `is_podman()` | Port tests |
| --- | --- | --- | --- |
| remote Podman | Podman 5.4 | `True` (was `False`) | 26 passed (was 10 failed) |
| remote Docker | Docker 29.4 | `False` | 26 passed |

Also simulated the Docker Desktop `desktop-linux` context from #757: `get_docker_host()` returns the context socket and `is_podman()` queries that same socket, returning `False` as expected.