### PR TITLE
fix(build): pin hatchling <1.32 to fix twine check CI failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,9 @@ dev = [
 
 # ---------- Hatchling build configuration ----------
 [build-system]
-requires = ["hatchling"]
+# hatchling>=1.32 emits Metadata-Version 2.5, which the pinned twine version
+# does not yet recognize as valid (https://github.com/pypa/twine/issues/1327).
+requires = ["hatchling>=1.26,<1.32"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]


### PR DESCRIPTION
Fixes #1096

## Problem
The `Run twine check` CI step fails on all PRs (e.g. run [31887608422](https://github.com/testcontainers/testcontainers-python/actions/runs/31887608422/job/95019090461?pr=1090) on #1090) with:

```
Checking dist/testcontainers-4.15.0-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Root cause
`hatchling>=1.32` started emitting `Metadata-Version: 2.5` in built wheel/sdist metadata. The pinned `twine` (6.2.0, via `packaging`) doesn't yet recognize `2.5` as valid and rejects the distribution. This is unrelated to any specific PR's diff — it's an unpinned build-backend version issue. See pypa/twine#1327.

## Fix
Pin `hatchling` to `>=1.26,<1.32` in `pyproject.toml`'s `[build-system]` so it keeps emitting `Metadata-Version: 2.4`, compatible with the current twine/packaging toolchain.

## Verification
Ran locally:
```
uv build && uv run twine check dist/*
```
Wheel METADATA now shows `Metadata-Version: 2.4`, and both wheel and sdist pass `twine check` (`PASSED`).
